### PR TITLE
Fix Organizer#with spec

### DIFF
--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -10,12 +10,13 @@ describe LightService::Organizer do
       with(user: user).reduce [AnAction]
     end
 
-    def self.some_method_with(context)
+    def self.some_method_with(user)
+      context = LightService::Context.new(user: user)
       with(context).reduce [AnAction]
     end
   end
 
-  let(:context) { ::LightService::Context.new(user: user) }
+  let!(:context) { ::LightService::Context.new(user: user) }
   let(:user) { double(:user) }
 
   context "when #with is called with hash" do
@@ -33,12 +34,13 @@ describe LightService::Organizer do
 
   context "when #with is called with Context" do
     it "does not create a context" do
+      LightService::Context.stub(:new).with(user: user).and_return(context)
       LightService::Context.should_not_receive(:make)
 
       AnAction.should_receive(:execute) \
               .with(context) \
               .and_return context
-      AnOrganizer.some_method_with(context)
+      AnOrganizer.some_method_with(user)
     end
   end
 


### PR DESCRIPTION
Fixes #3
Copying from that issue...
# 

``` ruby
      def with(data = {})
        @context = data.kind_of?(::LightService::Context) ?
                     data :
                     LightService::Context.make(data)
        self
      end
```

All specs still pass even when it's changed to this:

``` ruby
      def with(data = {})
        @context = LightService::Context.make(data)
        self
      end
```

a quick check on spec/organizer_spec.rb says #with should not create a context given that the parameters is a context.
