### PR TITLE
Add Requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ end
 I gave a [talk at RailsConf 2013](http://www.adomokos.com/2013/06/simple-and-elegant-rails-code-with.html) on
 simple and elegant Rails code where I told the story of how Light Service was extracted from the projects I had worked on.
 
+## Requirements
+
+This gem requires ruby 1.9.x
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
Tested from ruby 2.0.0 up to 1.8.7. Incompatible with 1.8.7. Although backporting is easy, everyone should move away from anything 1.8.x. :)
