### PR TITLE
Enable including a LightService::Organizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is how the organizer and actions interact with eachother:
 
 ```ruby
 class CalculatesTax
-  extend LightService::Organizer
+  include LightService::Organizer
 
   def self.for_order(order)
     with(order: order).reduce \
@@ -183,7 +183,7 @@ require 'light-service'
 module Yoyo
   class PushesLead
     include LightService::Action
-    extend LightService::Organizer
+    include LightService::Organizer
  
     executed do |context|
       lead = context.fetch(:lead)

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -1,15 +1,28 @@
 module LightService
   module Organizer
-    protected
-      def with(data = {})
-        @context = data.kind_of?(::LightService::Context) ?
-                     data :
-                     LightService::Context.make(data)
-        self
+    def self.included(base_class)
+      base_class.extend ClassMethods
+    end
+
+    module ClassMethods
+      def with(data)
+        new.with(data)
       end
 
-      def reduce(actions=[])
-        actions.reduce(@context) { |context, action| action.execute(context) }
+      def reduce(actions)
+        new.reduce(actions)
       end
+    end
+
+    def with(data = {})
+      @context = data.kind_of?(::LightService::Context) ?
+                 data :
+                 LightService::Context.make(data)
+      self
+    end
+
+    def reduce(actions=[])
+      actions.reduce(@context) { |context, action| action.execute(context) }
+    end
   end
 end

--- a/spec/acceptance/add_numbers_spec.rb
+++ b/spec/acceptance/add_numbers_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 class Organizer
-  extend LightService::Organizer
+  include LightService::Organizer
 
   def self.add_number(number)
     with(number: number).reduce \

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -4,7 +4,7 @@ describe LightService::Organizer do
   class AnAction; end
 
   class AnOrganizer
-    extend LightService::Organizer
+    include LightService::Organizer
 
     def self.some_method(user)
       with(user: user).reduce [AnAction]

--- a/spec/sample/tax/calculates_tax.rb
+++ b/spec/sample/tax/calculates_tax.rb
@@ -1,5 +1,5 @@
 class CalculatesTax
-  extend LightService::Organizer
+  include LightService::Organizer
 
   def self.for_order(order)
     with(order: order).reduce \


### PR DESCRIPTION
I remember you suggesting that it would be awesome if we could `include LightService::Organizer` instead of `extend LightService::Organizer`. Here's that needed changes for that. :tada: 

extra goodie: extending `LightService::Organizer` still works, though explicitly removed from the examples. Just revert the `organizer_spec.rb` to use `extend` instead of `include` to check. :+1: 
