### PR TITLE
skip_all option, similar to failure but used for non failure scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,38 @@ module Yoyo
 end
 ```
 
+Calling `set_failure!` on the context will stop execution of the remaining actions, in some cases you may want the same behaviour but not due to failure, in that case use `skip_all!`. `skip_all!` optionally takes a message argument.
+
+```ruby
+# organizer class registered to execute 2 actions
+class AddComment
+  extend LightService::Organizer
+
+  def self.to_post(args = {})
+    with(args).reduce [
+      SaveCommentAction,
+      PublishCommentAction
+    ]
+  end
+end
+
+# action to save comment data, conditionally will bypass the remaining actions
+class SaveCommentAction
+  include LightService::Action
+
+  executed do |context|
+    comment = context.fetch(:comment)
+    post = context.fetch(:post)
+    post.comments << comment
+    
+    unless comment.commenter.can_auto_approve_own_comment
+      # calling skip_all! will bypass PublishCommentAction execution
+      context.skip_all!
+    end
+  end
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -8,7 +8,7 @@ module LightService
     module Macros
       def executed
         define_singleton_method "execute" do |context|
-          return context if context.failure?
+          return context if context.failure? || context.skip_all?
 
           yield(context)
 

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -44,6 +44,10 @@ module LightService
       success? == false
     end
 
+    def skip_all?
+      @skip_all
+    end
+
     def set_success!(message)
       @message = message
       @outcome = ::LightService::Outcomes::SUCCESS
@@ -52,6 +56,11 @@ module LightService
     def set_failure!(message)
       @message = message
       @outcome = ::LightService::Outcomes::FAILURE
+    end
+
+    def skip_all!(message = nil)
+      @message = message
+      @skip_all = true
     end
 
   end

--- a/spec/action_base_spec.rb
+++ b/spec/action_base_spec.rb
@@ -10,6 +10,14 @@ module LightService
       end
     end
 
+    class SkippedAction
+      include LightService::Action
+
+      executed do |context|
+        context[:test_key] = "set_by_skipped_action"
+      end
+    end
+
     let(:context) { ::LightService::Context.new }
 
     context "when the action context has failure" do
@@ -27,6 +35,26 @@ module LightService
         DummyAction.execute(context)
 
         context.context_hash.keys.should eq [:test_key]
+      end
+    end
+
+    context "when the action context skips all" do
+      it "returns immediately" do
+        context.skip_all!
+
+        DummyAction.execute(context)
+
+        context.context_hash.keys.should be_empty
+      end
+
+      it "does not execute skipped actions" do
+        DummyAction.execute(context)
+
+        context.skip_all!
+
+        SkippedAction.execute(context)
+
+        context.context_hash.should eq ({:test_key => "test_value"})
       end
     end
 


### PR DESCRIPTION
Not sure if you want to introduce this or not? I have only been using light-service for a few hours so it is possible the code I came up with is smelly and that is why I encountered the need for `skip_all!` option

here is a contrived example to demonstrate usage - see `SaveCommentAction` for skip_all!

``` ruby
def add_comment
  @post = Post.find(params[:id])
  @comment = Comment.new(params[:comment])
  service_result = AddComment.to_post({ post: @post, comment: @comment })
  # ...
end

def approve_comment
  post = current_user.posts.find(params[:id])
  comment = @post.comments.find(params[:comment_id])
  service_result = ApproveComment.for_comment(comment)
  # ...
end

class AddComment
  extend LightService::Organizer

  def self.to_post(args = {})
    with(args).reduce [
      SaveCommentAction,
      PublishCommentAction
    ]
  end
end

class ApproveComment
  extend LightService::Organizer

  def self.for_comment(comment)
    with(comment: comment).reduce [
      PublishCommentAction,
      SendNoticeToCommenterAction
    ]
  end
end

class SaveCommentAction
  include LightService::Action

  executed do |context|
    comment = context.fetch(:comment)
    post = context.fetch(:post)

    post.comments << comment

    unless comment.commenter.can_auto_approve_own_comment
      context.skip_all!
    end
  end
end

class PublishCommentAction
  include LightService::Action

  executed do |context|
    comment = context.fetch(:comment)
    comment.update_attribute(:published, true)
  end
end

class SendNoticeToCommenterAction
  include LightService::Action

  executed do |context|
    comment = context.fetch(:comment)
    CommentMailer.send_confirmation(comment).deliver
  end
end
```
