### PR TITLE
Context.make coerces context parameter into hash

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -8,7 +8,7 @@ module LightService
     attr_accessor :outcome, :message
 
     def initialize(outcome=::LightService::Outcomes::SUCCESS, message='', context={})
-      @outcome, @message, @context = outcome, message, context
+      @outcome, @message, @context = outcome, message, context.to_hash
     end
 
     def self.make(context={})
@@ -33,6 +33,10 @@ module LightService
 
     # It's really there for testing and debugging
     def context_hash
+      @context.dup
+    end
+
+    def to_hash
       @context.dup
     end
 

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -11,9 +11,7 @@ module LightService
     end
 
     def with(data = {})
-      @context = data.kind_of?(::LightService::Context) ?
-                 data :
-                 LightService::Context.make(data)
+      @context = LightService::Context.make(data)
       self
     end
 

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -16,11 +16,34 @@ module LightService
       service_result[:test].should eq 1
     end
 
-    it "initializes the object with make" do
-      service_result = Context.make({:test => 1})
-      service_result.should be_success
-      service_result.message.should eq ""
-      service_result[:test].should eq 1
+    describe ".make" do
+      it "initializes the object with make" do
+        service_result = Context.make({:test => 1})
+        service_result.should be_success
+        service_result.message.should eq ""
+        service_result[:test].should eq 1
+      end
+
+      it "should try to coerce @context into a hash" do
+        a_hash = {test: 1}
+        service_result = Context.make(a_hash)
+        service_result.context_hash.should == {test: 1}
+
+        a_context = Context.make(test: 1)
+        service_result = Context.make(a_context)
+        service_result.context_hash.should == {test: 1}
+
+        expect { Context.make(nil)       }.to raise_error(NoMethodError)
+        expect { Context.make([])        }.to raise_error(NoMethodError)
+        expect { Context.make([1, 2, 3]) }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "#to_hash" do
+      it "converts into the context_hash" do
+        Context.make(test: 1).to_hash.should == {test: 1}
+        Context.make({}).to_hash.should == {}
+      end
     end
 
     context "when created" do

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -31,17 +31,4 @@ describe LightService::Organizer do
       AnOrganizer.some_method(user)
     end
   end
-
-  context "when #with is called with Context" do
-    it "does not create a context" do
-      LightService::Context.stub(:new).with(user: user).and_return(context)
-      LightService::Context.should_not_receive(:make)
-
-      AnAction.should_receive(:execute) \
-              .with(context) \
-              .and_return context
-      AnOrganizer.some_method_with(user)
-    end
-  end
-
 end


### PR DESCRIPTION
Additional steps done:
- make LightService::Context respond to to_hash (as required by Hash())
- remove unnecessary test

for https://github.com/adomokos/light-service/issues/15
replacment for https://github.com/adomokos/light-service/pull/18 as `Kernel#Hash` is not defined in ruby 1.9
