### PR TITLE
Context rewrite.

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -4,40 +4,24 @@ module LightService
     FAILURE = 1
   end
 
-  class Context
+  class Context < Hash
     attr_accessor :outcome, :message
 
-    def initialize(outcome=::LightService::Outcomes::SUCCESS, message='', context={})
-      @outcome, @message, @context = outcome, message, context.to_hash
+    def initialize(context={}, outcome=::LightService::Outcomes::SUCCESS, message='')
+      @outcome, @message = outcome, message
+      context.to_hash.each {|k,v| self[k] = v}
     end
 
     def self.make(context={})
-      Context.new(::LightService::Outcomes::SUCCESS, '', context)
+      Context.new(context, ::LightService::Outcomes::SUCCESS, '')
     end
 
     def add_to_context(values)
-      @context.merge! values
+      self.merge! values
     end
 
-    def [](index)
-      @context[index]
-    end
-
-    def []=(index, value)
-      @context[index] = value
-    end
-
-    def fetch(index)
-      @context.fetch(index)
-    end
-
-    # It's really there for testing and debugging
     def context_hash
-      @context.dup
-    end
-
-    def to_hash
-      @context.dup
+      self.dup
     end
 
     def success?
@@ -66,6 +50,5 @@ module LightService
       @message = message
       @skip_all = true
     end
-
   end
 end

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("rspec", "~> 2.0")
   gem.add_development_dependency("simplecov", "~> 0.7.1")
+  gem.add_development_dependency("pry", "0.9.12.2")
 end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 
 module LightService
   describe Context do
-    subject { Context.new(Outcomes::SUCCESS, "some_message", {:test => 1}) }
+    subject { Context.new({:test => 1}, Outcomes::SUCCESS, "some_message") }
 
     it "initializes the object with default arguments" do
-      service_result = Context.new
+      service_result = Context.new({test: 1})
       service_result.should be_success
-      service_result.message.should eq ''
-      service_result.to_hash.should eq({})
+      service_result.message.should eq ""
+      service_result[:test].should eq 1
     end
 
     it "initializes the object with the context" do


### PR DESCRIPTION
So one boring day, I rewrote the Context because I've been itching to do so for quite some time now.

I can keep it on my own fork but I just want to get it out there so that I can get feedback:
- `LightService::Context` now inherits from Hash
- breaks the current API:
  - from `Context.new(outcome, message, context)` -> `Context.new(context, outcome, message)`
    Conflicts:
    lib/light-service/context.rb

Why?
- from our usage so far, Context is actually a hash plus extra methods (`failure?`, `skip_all?`)... but mostly a Hash. So why not expose Hash's default methods? Unless there is a good reason to hide the default Hash methods, we should make them available.
- makes the codebase actually shorter by removing `Context#methods` that just delegates to `@context`.
- I could actually make it shorter by removing `Context.make`, since it can be replaced by `Context.new` now. By doing that, we can simply follow Ruby conventions. I can also remove `#context_hash`, but the other pull request for deprecating that method is still pending.

If this were to be merged. This will probably go in a x.0.0 version.
