### PR TITLE
Context#make returns the same context object if the argument is already a Context

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -14,6 +14,7 @@ module LightService
     end
 
     def self.make(context={})
+      return context if context.is_a?(Context)
       self.new(context, ::LightService::Outcomes::SUCCESS, '')
     end
 

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -48,6 +48,15 @@ module LightService
         let(:invalid_params) { [] }
         it { should raise_error(NoMethodError) }
       end
+
+      context "data is a context" do
+        let(:original_context) { Context.new }
+
+        it "returns the same context object" do
+          new_context = Context.make(original_context)
+          expect(new_context.object_id).to eq(original_context.object_id)
+        end
+      end
     end
 
     describe "#to_hash" do


### PR DESCRIPTION
When you have a context that is passed into sub organizer-actions, the context that the sub classes act upon are different contexts. Any assignments done on those are not seen in the caller's context.

This fixes it.

Worked on this with @padi
