### PR TITLE
WIP: Developer adds expectations and promises to an action

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ end
 
 class LooksUpTaxPercentageAction
   include LightService::Action
+  expects :order
 
   executed do |context|
-    order = context.fetch(:order)
     tax_ranges = TaxRange.for_region(order.region)
 
     next context if object_is_nil?(tax_ranges, context, 'The tax ranges were not found')
@@ -107,11 +107,9 @@ end
 
 class CalculatesOrderTaxAction
   include ::LightService::Action
+  expects :order, :tax_percentage
 
   executed do |context|
-    order = context.fetch(:order)
-    tax_percentage = context.fetch(:tax_percentage)
-
     order.tax = (order.total * (tax_percentage/100)).round(2)
   end
 
@@ -119,10 +117,9 @@ end
 
 class ProvidesFreeShippingAction
   include LightService::Action
+  expects :order
 
   executed do |context|
-    order = context.fetch(:order)
-
     if order.total_with_tax > 200
       order.provide_free_shipping!
     end

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -6,10 +6,28 @@ module LightService
     end
 
     module Macros
+      def expects(*args)
+        @expects_keys = args
+      end
+
+      def expects_keys
+        @expects_keys ||= []
+      end
+
+      def promises(*args)
+        @promises_keys = args
+      end
+
+      def promises_keys
+        @promises_keys ||= []
+      end
+
       def executed
         define_singleton_method "execute" do |context = {}|
           action_context = create_action_context(context)
           return action_context if action_context.failure? || action_context.skip_all?
+
+          define_expectation_accessors action_context
 
           yield(action_context)
 
@@ -26,6 +44,19 @@ module LightService
 
         LightService::Context.make(context)
       end
+
+      def define_expectation_accessors(context)
+        expects_keys.each do |x|
+          if context.has_key?(x)
+            define_singleton_method x do
+              context.fetch(x)
+            end
+          else
+            fail ArgumentError, "expected :#{x} to be in the context"
+          end
+        end
+      end
+
     end
 
   end

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -18,7 +18,49 @@ module LightService
       end
     end
 
+    class ExpectantAction
+      include LightService::Action
+      expects :tea, :milk
+
+      executed do |context|
+        context[:color] = tea
+        context[:thickness] = milk
+      end
+    end
+
+    class PromisingAction
+      include LightService::Action
+      promises :milk_tea
+    end
+
     let(:context) { ::LightService::Context.make }
+
+    context "when the action expects keys in the context" do
+      context "keys exist" do
+        it "creates methods to access the values in the context" do
+          resulting_context = ExpectantAction.execute(
+            tea: "black",
+            milk: "full cream",
+          )
+          expect(resulting_context[:color]).to eq "black"
+          expect(resulting_context[:thickness]).to eq "full cream"
+        end
+      end
+
+      context "keys do not exist" do
+        it "raisees an error" do
+          expect {
+            ExpectantAction.execute(tea: "black")
+          }.to raise_error(ArgumentError, "expected :milk to be in the context")
+        end
+      end
+    end
+
+    describe ".promises_keys" do
+      it "returns the keys it promises to set in the context" do
+        expect(PromisingAction.promises_keys).to eq [:milk_tea]
+      end
+    end
 
     context "when the action context has failure" do
       it "returns immediately" do


### PR DESCRIPTION
(1) Can access these expectations in the executed block
(2) Adds class getter `expects_keys`
(3) Adds class getter `promises_keys`

There's one more piece missing: where the organiser checks (possibly through a matcher) its actions to see if they're compatible. Should we do it upon reduce? This means we won't be able to do it loading of the class, only when we actually execute the organiser.
