### PR TITLE
Move stop_processing? to Context

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -17,7 +17,7 @@ module LightService
       def executed
         define_singleton_method "execute" do |context = {}|
           action_context = create_action_context(context)
-          return action_context if stop_processing?(action_context)
+          return action_context if action_context.stop_processing?
 
           ContextKeyVerifier.verify_expected_keys_are_in_context(action_context, @expected_keys)
 
@@ -64,10 +64,6 @@ module LightService
           next if value == VALUE_NOT_SET
           context[key] = value
         end
-      end
-
-      def stop_processing?(context)
-        context.failure? || context.skip_all?
       end
 
       VALUE_NOT_SET = "___value_was_not_set___"

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -70,5 +70,8 @@ module LightService
       @skip_all = true
     end
 
+    def stop_processing?
+      failure? || skip_all?
+    end
   end
 end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -79,5 +79,19 @@ module LightService
       expect(context).to be_skip_all
     end
 
+    context "stopping additional processing in an action" do
+      let(:context) { Context.make }
+
+      it "flags processing to stop on failure" do
+        context.fail!("on purpose")
+        expect(context.stop_processing?).to be_true
+      end
+
+      it "flags processing to stop when remaining actions should be skipped" do
+        context.skip_all!
+        expect(context.stop_processing?).to be_true
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Executing an action is an action concern but we're digging into the
details of the Context to know if we should execute an action or not.
Since we set skipping, failing, and succeeding on a context, move the
implementation details of stopping processing to the context as well and
have the action ask the context if we should continue.
