### PR TITLE
Prefix private instance variables with an `_`

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -7,11 +7,11 @@ module LightService
 
     module Macros
       def expects(*args)
-        @expected_keys = args
+        @_expected_keys = args
       end
 
       def promises(*args)
-        @promised_keys = args
+        @_promised_keys = args
       end
 
       def executed
@@ -19,7 +19,7 @@ module LightService
           action_context = create_action_context(context)
           return action_context if stop_processing?(action_context)
 
-          ContextKeyVerifier.verify_expected_keys_are_in_context(action_context, @expected_keys)
+          ContextKeyVerifier.verify_expected_keys_are_in_context(action_context, @_expected_keys)
 
           define_expectations_readers(context)
           define_promises_accessors(context)
@@ -27,7 +27,7 @@ module LightService
           yield(action_context)
 
           set_promises_in_context(action_context)
-          ContextKeyVerifier.verify_promised_keys_are_in_context(action_context, @promised_keys)
+          ContextKeyVerifier.verify_promised_keys_are_in_context(action_context, @_promised_keys)
         end
       end
 
@@ -50,16 +50,16 @@ module LightService
       end
 
       def define_promises_accessors(context)
-        return unless @promised_keys
-        @promised_keys.each do |key|
+        return unless @_promised_keys
+        @_promised_keys.each do |key|
           instance_variable_set("@#{key}", VALUE_NOT_SET)
           self.class.send(:attr_accessor, key)
         end
       end
 
       def set_promises_in_context(context)
-        return unless @promised_keys
-        @promised_keys.each do |key|
+        return unless @_promised_keys
+        @_promised_keys.each do |key|
           value = instance_variable_get("@#{key}")
           next if value == VALUE_NOT_SET
           context[key] = value


### PR DESCRIPTION
I've seen various projects prefix private variables that are defined and used as part of macros with an `_`. This change brings us in line that community pattern and prevents accidental leakage into the action itself.

We don't instantiate action classes so this may be a non-issue. Not caring either way if it's merged or not. Just wanted to throw it out there. :smiley:
