### PR TITLE
Ignore ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 Gemfile.lock
 InstalledFiles
 _yardoc


### PR DESCRIPTION
Since I assume we're supporting more ruby versions.

The reason why I put it in that particular line: sorted the order of each line. Luckily, they were already in order before I added the change.
