### PR TITLE
Do not raise a sub-context's error

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -37,7 +37,7 @@ module LightService
           # Store the action within the context
           action_context.current_action = self
 
-          Context::KeyVerifier.verify_keys(action_context) do
+          Context::KeyVerifier.verify_keys(action_context, self) do
             action_context.define_accessor_methods_for_keys(all_keys)
 
             yield(action_context)

--- a/lib/light-service/context/key_verifier.rb
+++ b/lib/light-service/context/key_verifier.rb
@@ -2,9 +2,9 @@ module LightService; class Context
   class KeyVerifier
     attr_reader :context, :action
 
-    def initialize(context)
+    def initialize(context, action)
       @context = context
-      @action = context.current_action
+      @action = action
     end
 
     def are_all_keys_in_context?(keys)
@@ -40,13 +40,13 @@ module LightService; class Context
       context
     end
 
-    def self.verify_keys(context, &block)
-      ReservedKeysVerifier.new(context).verify
-      ExpectedKeyVerifier.new(context).verify
+    def self.verify_keys(context, action, &block)
+      ReservedKeysVerifier.new(context, action).verify
+      ExpectedKeyVerifier.new(context, action).verify
 
       block.call
 
-      PromisedKeyVerifier.new(context).verify
+      PromisedKeyVerifier.new(context, action).verify
     end
   end
 

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -58,4 +58,26 @@ describe LightService::Organizer do
         .not_to raise_error
     end
   end
+
+  context "when the organizer is also an action", "and the organizer rescues exceptions of its sub-actions" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+        extend LightService::Action
+
+        executed do |ctx|
+          begin
+            with(ctx).
+              reduce(TestDoubles::MakesTeaPromisingKeyButRaisesException)
+          rescue
+          end
+        end
+      end
+    end
+
+    it "does not raise an error concerning a sub-action's missing keys" do
+      expect { organizer.execute }.not_to raise_error
+    end
+  end
+
 end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -213,4 +213,20 @@ module TestDoubles
       context.product = context.number + 3
     end
   end
+
+  class MakesTeaPromisingKeyButRaisesException
+    extend LightService::Action
+    promises :product
+
+    executed do |context|
+      context.product = make_product
+    end
+
+    private
+
+    def self.make_product
+      fail "Fail"
+    end
+  end
+
 end


### PR DESCRIPTION
Happens when the an organizer-action rescues errors and a child action raises an exception before being able to set a promised key.

Fix is to not rely on the context's `current_action`, which is overwritten every time an action is executed.