### PR TITLE
Assign expected and promised keys to Action subclass

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -10,6 +10,12 @@ module LightService
       base_class.extend Macros
     end
 
+    def inherited(subclass)
+      subclass.instance_variable_set(:@_expected_keys, @_expected_keys)
+      subclass.instance_variable_set(:@_promised_keys, @_promised_keys)
+      super(subclass)
+    end
+
     module Macros
       def expects(*args)
         @_expected_keys ||= []

--- a/spec/action_inheritance_spec.rb
+++ b/spec/action_inheritance_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'test_doubles'
+
+describe LightService::Action do
+  describe "when an Action is subclassed" do
+    class MakesTeaWithMilkSubclass < TestDoubles::MakesTeaWithMilkAction
+    end
+
+    class ActionWithTotallyDifferentKeys
+      extend LightService::Action
+
+      expects :no_one_else_expects_this
+      promises :no_one_else_promises_this
+    end
+
+    it "subclass inherits expected and promised keys" do
+      expect(MakesTeaWithMilkSubclass.expected_keys).
+        to match_array(TestDoubles::MakesTeaWithMilkAction.expected_keys)
+
+      expect(MakesTeaWithMilkSubclass.promised_keys).
+        to match_array(TestDoubles::MakesTeaWithMilkAction.promised_keys)
+    end
+
+    it "subclass behaves like its parent" do
+      subclass_result = MakesTeaWithMilkSubclass.execute(tea: "tea", milk: "milk")
+      parent_result = TestDoubles::MakesTeaWithMilkAction.execute(tea: "tea", milk: "milk")
+
+      expect(subclass_result).to eq(parent_result)
+    end
+
+    it "expected and promised keys are not mixed with other (non-subclass) Actions" do
+      expect(
+        MakesTeaWithMilkSubclass.expected_keys &
+        ActionWithTotallyDifferentKeys.expected_keys
+      ).to eq([])
+
+      expect(
+        MakesTeaWithMilkSubclass.promised_keys &
+        ActionWithTotallyDifferentKeys.promised_keys
+      ).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Currently when an `Action` is subclassed the subclass cannot access the expected and promised keys using dot notation.
```ruby
class AnAction
  extend LightService::Action
  expects :expected_key
  executed do |context|
    # do stuff
  end
end

class AnActionSubclass
  executed do |context|
    # do stuff
    context.expected_key # raises an error
  end
end
```

This PR will allow the above to work.

