### PR TITLE
Adds around_each to WithReducers for organizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: ruby
+
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
+  - 2.3.0
+
+before_install:
+  - gem install bundler
+
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec
+
 gemfile:
   - gemfiles/activesupport_3.gemfile
-  - gemfiles/activesupport_4.gemfile
+  - gemfiles/activesupport_4.gemfileset

--- a/lib/light-service/organizer/with_reducer_log_decorator.rb
+++ b/lib/light-service/organizer/with_reducer_log_decorator.rb
@@ -19,6 +19,11 @@ module LightService; module Organizer
       self
     end
 
+    def around_each(handler)
+      decorated.around_each(handler)
+      self
+    end
+
     def reduce(*actions)
       decorated.reduce(*actions) do |context, action|
         next if logged?

--- a/spec/acceptance/around_each_spec.rb
+++ b/spec/acceptance/around_each_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'test_doubles'
+
+describe "Executing arbitrary code around each action" do
+  def assert_before_action_execute_log
+    expect(MyLogger).to receive(:info).with(TestDoubles::AddsTwoActionWithFetch, {:number => 0})
+  end
+
+  def assert_after_action_execute_log
+    expect(MyLogger).to receive(:info).with(TestDoubles::AddsTwoActionWithFetch, {:number => 2})
+  end
+
+  it "can be used to log data" do
+    MyLogger = double
+    context = {:number => 0}
+
+    assert_before_action_execute_log
+    assert_after_action_execute_log
+
+    result = TestDoubles::AroundEachOrganizer.add(context)
+
+    expect(result.fetch(:number)).to eq(2)
+  end
+end
+

--- a/spec/organizer/with_reducer_spec.rb
+++ b/spec/organizer/with_reducer_spec.rb
@@ -19,6 +19,16 @@ describe LightService::Organizer::WithReducer do
     expect(result).to be_success
   end
 
+  it "executes a handler around each action and continues reducing" do
+    expect(action1).to receive(:execute).with(context).and_return(context)
+    expect(TestDoubles::AroundEachNullHandler).to receive(:call).with(action1, context).and_yield
+
+    result = described_class.new.with(context).around_each(TestDoubles::AroundEachNullHandler).reduce([action1])
+
+    expect(result).to eq(context)
+    expect(result).to be_success
+  end
+
   context "when FailWithRollbackError is caught" do
     it "reduces the rollback" do
       expect(action1).to receive(:execute).with(context).and_return(context)

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -1,6 +1,29 @@
 # A collection of Action and Organizer dummies used in specs
 
 module TestDoubles
+  class AroundEachNullHandler
+    def self.call(action, context)
+      yield
+    end
+  end
+
+  class AroundEachLoggerHandler
+    def self.call(action, context)
+      MyLogger.info(action, context)
+      result = yield
+      MyLogger.info(action, context)
+
+      result
+    end
+  end
+
+  class AroundEachOrganizer
+    extend LightService::Organizer
+    def self.add(action_arguments)
+      with(action_arguments).around_each(AroundEachLoggerHandler).reduce([AddsTwoActionWithFetch])
+    end
+  end
+
   class AddsTwoActionWithFetch
     extend LightService::Action
 


### PR DESCRIPTION
The ambition of this commit is to unobtrusively
gather arbitrary metrics from your application.

An around_each receiver follows the duck type of:

```ruby
def call(action, context)
```
The rest is up to you!

Here is an example that could be used to check persisted counts in a
data pipeline (there is another example in the README for logging
duration or profiling actions):

```ruby
class DataCounterCheck
  def self.call(action, context)
    before_count = context.data.count
    result = yield
    after_count = context.persisted_data.count

    LightService::Configuration.logger.info({
      :action       => action,
      :before_count => before_count,
      :after_count  => after_count,
      :difference   => before_count - after_count,
    })

    result
  end
end
```

### Design Consideration

I tried to focus most on the readability of the API, and I think it reads nicely method-chained.
I chose to simply yield the block passed by light-service so the around each objects do not have
to change even if the way light-service chooses to execute actions does.  It's fairly open-ended, but still simple enough, I hope.

### Complexity

The around_each method call provides enough to do the use cases I can
foresee without overcomplicating the software.  It does add some
assignments and conditionals, so it is close to a new abstraction, but
probably not quite yet.  It changes the flog by such:

```flog lib/light-service/organizer -g```

Before:

```
123.2: flog total
     7.7: flog/method average

    55.5: LightService::Organizer::WithReducerLogDecorator total
    40.2: LightService::Organizer::WithReducerLogDecorator#reduce
          lib/light-service/organizer/with_reducer_log_decorator.rb:27
    15.2: LightService::Organizer::WithReducerLogDecorator#with
          lib/light-service/organizer/with_reducer_log_decorator.rb:13

    19.0: LightService::Organizer::WithReducer total
    11.6: LightService::Organizer::WithReducer#reduce
          lib/light-service/organizer/with_reducer.rb:10
     7.4: LightService::Organizer::WithReducer#reduce_rollback
          lib/light-service/organizer/with_reducer.rb:28
```

After:

```
128.4: flog total
    7.6: flog/method average

    55.5: LightService::Organizer::WithReducerLogDecorator total
    40.2: LightService::Organizer::WithReducerLogDecorator#reduce
          lib/light-service/organizer/with_reducer_log_decorator.rb:27
    15.2: LightService::Organizer::WithReducerLogDecorator#with
          lib/light-service/organizer/with_reducer_log_decorator.rb:13

    23.1: LightService::Organizer::WithReducer total
    15.7: LightService::Organizer::WithReducer#reduce
          lib/light-service/organizer/with_reducer.rb:15
     7.4: LightService::Organizer::WithReducer#reduce_rollback
          lib/light-service/organizer/with_reducer.rb:37
```
### Benchmarks

It has a negligible impact on the organizer's reduction performance -- it is about 1.01x slower with around_each calls.

From this script https://gist.github.com/bwvoss/8483ecc4a0315e724fed, here are some before and after IPS benchmarks:

```
Calculating -------------------------------------

         default     884.000  i/100ms
         around_each 855.000  i/100ms

-------------------------------------------------

         default      8.912k (± 2.4%) i/s - 45.084k
         around_each  8.786k (± 3.6%) i/s - 44.460k

Comparison:

         default:     8911.9 i/s
         around_each: 8786.1 i/s - 1.01x slower
```