### PR TITLE
Not yet ready for ActiveSupport 5 yet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
 Documentation:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/Encoding:
   Enabled: false
 

--- a/lib/light-service/version.rb
+++ b/lib/light-service/version.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 module LightService
   VERSION = "0.6.1".freeze
 end

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LightService::VERSION
 
-  gem.add_dependency("activesupport", ">= 3.0")
+  gem.add_dependency("activesupport", ">= 3.0", "< 5")
 
   gem.add_development_dependency("rspec", "~> 3.0")
   gem.add_development_dependency("simplecov", "~> 0.11")

--- a/spec/acceptance/message_localization_spec.rb
+++ b/spec/acceptance/message_localization_spec.rb
@@ -38,7 +38,8 @@ describe "Localization Adapter" do
   before do
     I18n.backend.store_translations(
       :en,
-      :tests_localization_invocation_options_action => {
+      :tests_localization_invocation_options_action =>
+      {
         :light_service => {
           :failures => {
             :some_failure_reason => "This has failed",
@@ -49,7 +50,8 @@ describe "Localization Adapter" do
             :success_with_interpolation => "Passed with %{reason}"
           }
         }
-      })
+      }
+    )
   end
 
   describe "passing a simple string message" do

--- a/spec/acceptance/rollback_spec.rb
+++ b/spec/acceptance/rollback_spec.rb
@@ -19,7 +19,7 @@ class AddsOneWithRollbackAction
   promises :number
 
   executed do |context|
-    context.fail_with_rollback! if context.number == 0
+    context.fail_with_rollback! if context.number.zero?
 
     context.number += 1
   end

--- a/spec/organizer_key_aliases_spec.rb
+++ b/spec/organizer_key_aliases_spec.rb
@@ -13,7 +13,8 @@ describe "organizer aliases macro" do
           [
             TestDoubles::PromisesPromisedKeyAction,
             TestDoubles::ExpectsExpectedKeyAction
-          ])
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
It won't work with AS 5.0. Specifying `"< 5.0"` in gemspec for now. Issue to support it has been created: #86.