### PR TITLE
Slimming down ActiveSupport dependency

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -7,7 +7,7 @@ module LightService
     def self.included(base_class)
       msg = "including LightService::Action is deprecated. " \
             "Please use `extend LightService::Action` instead"
-      ActiveSupport::Deprecation.warn(msg)
+      warn(msg)
       base_class.extend Macros
     end
 

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -50,7 +50,7 @@ module LightService
     def outcome
       msg = '`Context#outcome` attribute reader is ' \
             'DEPRECATED and will be removed'
-      ActiveSupport::Deprecation.warn(msg)
+      warn(msg)
       @outcome
     end
 

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -8,7 +8,7 @@ module LightService
     def self.included(base_class)
       warning_msg = "including LightService::Organizer is deprecated. " \
                     "Please use `extend LightService::Organizer` instead"
-      ActiveSupport::Deprecation.warn(warning_msg)
+      warn(warning_msg)
       base_class.extend ClassMethods
       base_class.extend Macros
     end

--- a/spec/acceptance/include_warning_spec.rb
+++ b/spec/acceptance/include_warning_spec.rb
@@ -6,7 +6,7 @@ describe "Including is discouraged" do
     it "gives warning" do
       expected_msg = "including LightService::Organizer is deprecated. " \
                      "Please use `extend LightService::Organizer` instead"
-      expect(ActiveSupport::Deprecation).to receive(:warn)
+      expect(LightService::Organizer).to receive(:warn)
         .with(expected_msg)
 
       class OrganizerIncludingLS
@@ -19,7 +19,7 @@ describe "Including is discouraged" do
     it "gives warning" do
       expected_msg = "including LightService::Action is deprecated. " \
                      "Please use `extend LightService::Action` instead"
-      expect(ActiveSupport::Deprecation).to receive(:warn)
+      expect(LightService::Action).to receive(:warn)
         .with(expected_msg)
 
       class ActionIncludingLS

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -152,7 +152,7 @@ describe LightService::Context do
   end
 
   it "warns about the outcome attribute reader being deprecated" do
-    expect(ActiveSupport::Deprecation).to receive(:warn)
+    expect(context).to receive(:warn)
 
     expect(context.outcome).to eq(::LightService::Outcomes::SUCCESS)
   end


### PR DESCRIPTION
In order to get rid of ActiveSupport, I'd like to trim the project's
dependency on it. This is the first step of doing that.