### PR TITLE
Issuing a Warning when the Organizer does not have a 'call' method

### DIFF
--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -17,7 +17,7 @@ module LightService
     # In case this module is included
     module ClassMethods
       def with(data = {})
-        VerifyCallMethodExists.call(self)
+        VerifyCallMethodExists.call(self, caller.first)
         data[:_aliases] = @aliases if @aliases
         WithReducerFactory.make(self).with(data)
       end
@@ -30,7 +30,10 @@ module LightService
       # use `call` method name going forward.
       # This should be removed eventually.
       class VerifyCallMethodExists
-        def self.call(klass)
+        def self.call(klass, first_caller = '')
+          invoker_method = caller_method(first_caller)
+          return if invoker_method == 'call'
+
           call_method_exists = klass.methods.include?(:call)
           return if call_method_exists
 
@@ -39,6 +42,12 @@ module LightService
                         "should be named `call`. " \
                         "Please use #{klass}.call going forward."
           ActiveSupport::Deprecation.warn(warning_msg)
+        end
+
+        def self.caller_method(first_caller)
+          return nil unless first_caller =~ /`(.*)'/
+
+          Regexp.last_match[1]
         end
       end
     end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -11,19 +11,35 @@ module LightService
       warning_msg = "including LightService::Organizer is deprecated. " \
                     "Please use `extend LightService::Organizer` instead"
       ActiveSupport::Deprecation.warn(warning_msg)
-      base_class.extend ClassMethods
-      base_class.extend Macros
+      extended(base_class)
     end
 
     # In case this module is included
     module ClassMethods
       def with(data = {})
+        VerifyCallMethodExists.call(self)
         data[:_aliases] = @aliases if @aliases
         WithReducerFactory.make(self).with(data)
       end
 
       def reduce(*actions)
         with({}).reduce(actions)
+      end
+
+      # We need to make sure existing users will
+      # use `call` method name going forward.
+      # This should be removed eventually.
+      class VerifyCallMethodExists
+        def self.call(klass)
+          call_method_exists = klass.methods.include?(:call)
+          return if call_method_exists
+
+          warning_msg = "The <#{klass.name}> class is an organizer, " \
+                        "its entry method (the one that calls with & reduce) " \
+                        "should be named `call`. " \
+                        "Please use #{klass}.call going forward."
+          ActiveSupport::Deprecation.warn(warning_msg)
+        end
       end
     end
 

--- a/spec/acceptance/add_numbers_spec.rb
+++ b/spec/acceptance/add_numbers_spec.rb
@@ -3,7 +3,7 @@ require 'test_doubles'
 
 describe TestDoubles::AdditionOrganizer do
   it "Adds 1, 2 and 3 to the initial value of 1" do
-    result = TestDoubles::AdditionOrganizer.add_numbers 1
+    result = TestDoubles::AdditionOrganizer.call(1)
     number = result.fetch(:product)
 
     expect(number).to eq(7)

--- a/spec/acceptance/around_each_spec.rb
+++ b/spec/acceptance/around_each_spec.rb
@@ -19,7 +19,7 @@ describe "Executing arbitrary code around each action" do
     assert_before_action_execute_log
     assert_after_action_execute_log
 
-    result = TestDoubles::AroundEachOrganizer.add(context)
+    result = TestDoubles::AroundEachOrganizer.call(context)
 
     expect(result.fetch(:number)).to eq(2)
   end

--- a/spec/acceptance/message_localization_spec.rb
+++ b/spec/acceptance/message_localization_spec.rb
@@ -4,7 +4,7 @@ require "test_doubles"
 class TestsLocalizationAdapter
   extend LightService::Organizer
 
-  def self.with_message(pass_or_fail, message_or_key, i18n_options = {})
+  def self.call(pass_or_fail, message_or_key, i18n_options = {})
     with(
       :pass_or_fail => pass_or_fail,
       :message_or_key => message_or_key,
@@ -27,11 +27,11 @@ class TestsLocalizationInvocationOptionsAction
 end
 
 def pass_with(message_or_key, i18n_options = {})
-  TestsLocalizationAdapter.with_message(true, message_or_key, i18n_options)
+  TestsLocalizationAdapter.call(true, message_or_key, i18n_options)
 end
 
 def fail_with(message_or_key, i18n_options = {})
-  TestsLocalizationAdapter.with_message(false, message_or_key, i18n_options)
+  TestsLocalizationAdapter.call(false, message_or_key, i18n_options)
 end
 
 describe "Localization Adapter" do

--- a/spec/acceptance/not_having_call_method_warning_spec.rb
+++ b/spec/acceptance/not_having_call_method_warning_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'test_doubles'
+
+describe "Organizer should invoke with/reduce from a call method" do
+  context "when the organizer does not have a `call` method" do
+    it "gives warning" do
+      expect(ActiveSupport::Deprecation)
+        .to receive(:warn)
+        .with(/^The <OrganizerWithoutCallMethod> class is an organizer/)
+
+      class OrganizerWithoutCallMethod
+        extend LightService::Organizer
+
+        def self.do_something
+          reduce([])
+        end
+      end
+
+      OrganizerWithoutCallMethod.do_something
+    end
+  end
+
+  context "when the organizer has the `call` method" do
+    it "does not issue a warning" do
+      expect(ActiveSupport::Deprecation)
+        .not_to receive(:warn)
+
+      class OrganizerWithCallMethod
+        extend LightService::Organizer
+
+        def self.call
+          reduce([])
+        end
+      end
+
+      OrganizerWithCallMethod.call
+    end
+  end
+end

--- a/spec/acceptance/rollback_spec.rb
+++ b/spec/acceptance/rollback_spec.rb
@@ -4,7 +4,7 @@ require 'test_doubles'
 class RollbackOrganizer
   extend LightService::Organizer
 
-  def self.for(number)
+  def self.call(number)
     with(:number => number).reduce(
       AddsOneWithRollbackAction,
       TestDoubles::AddsTwoAction,
@@ -47,7 +47,7 @@ end
 class RollbackOrganizerWithNoRollback
   extend LightService::Organizer
 
-  def self.for(number)
+  def self.call(number)
     with(:number => number).reduce(
       TestDoubles::AddsOneAction,
       TestDoubles::AddsTwoAction,
@@ -70,7 +70,7 @@ end
 class RollbackOrganizerWithMiddleRollback
   extend LightService::Organizer
 
-  def self.for(number)
+  def self.call(number)
     with(:number => number).reduce(
       TestDoubles::AddsOneAction,
       AddsTwoActionWithRollback,
@@ -96,7 +96,7 @@ end
 
 describe "Rolling back actions when there is a failure" do
   it "Adds 1, 2, 3 to 1 and rolls back " do
-    result = RollbackOrganizer.for 1
+    result = RollbackOrganizer.call 1
     number = result.fetch(:number)
 
     expect(result).to be_failure
@@ -105,7 +105,7 @@ describe "Rolling back actions when there is a failure" do
   end
 
   it "won't error out when actions don't define rollback" do
-    result = RollbackOrganizerWithNoRollback.for 1
+    result = RollbackOrganizerWithNoRollback.call 1
     number = result.fetch(:number)
 
     expect(result).to be_failure
@@ -114,7 +114,7 @@ describe "Rolling back actions when there is a failure" do
   end
 
   it "rolls back properly when triggered with an action in the middle" do
-    result = RollbackOrganizerWithMiddleRollback.for 1
+    result = RollbackOrganizerWithMiddleRollback.call 1
     number = result.fetch(:number)
 
     expect(result).to be_failure
@@ -123,7 +123,7 @@ describe "Rolling back actions when there is a failure" do
   end
 
   it "rolls back from the first action" do
-    result = RollbackOrganizer.for 0
+    result = RollbackOrganizer.call 0
     number = result.fetch(:number)
 
     expect(result).to be_failure

--- a/spec/organizer_key_aliases_spec.rb
+++ b/spec/organizer_key_aliases_spec.rb
@@ -8,7 +8,7 @@ describe "organizer aliases macro" do
 
       aliases :promised_key => :expected_key
 
-      def self.do_something(ctx = {})
+      def self.call(ctx = {})
         with(ctx).reduce(
           [
             TestDoubles::PromisesPromisedKeyAction,
@@ -21,7 +21,7 @@ describe "organizer aliases macro" do
 
   context "when aliases is invoked" do
     it "makes aliases available to the actions" do
-      result = organizer_with_alias.do_something
+      result = organizer_with_alias.call
       expect(result[:expected_key]).to eq(result[:promised_key])
       expect(result.expected_key).to eq(result[:promised_key])
     end

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -16,7 +16,7 @@ describe LightService::Organizer do
     end
 
     it "implicitly creates a Context" do
-      result = TestDoubles::AnOrganizer.do_something(:user => user)
+      result = TestDoubles::AnOrganizer.call(:user => user)
       expect(result).to eq(ctx)
     end
   end
@@ -32,7 +32,7 @@ describe LightService::Organizer do
     end
 
     it "uses that Context without recreating it" do
-      result = TestDoubles::AnOrganizer.do_something(ctx)
+      result = TestDoubles::AnOrganizer.call(ctx)
       expect(result).to eq(ctx)
     end
   end
@@ -64,7 +64,7 @@ describe LightService::Organizer do
         extend LightService::Organizer
         aliases :foo => :bar
 
-        def self.do_stuff
+        def self.call
           with.reduce(TestDoubles::AnAction)
         end
       end
@@ -80,7 +80,7 @@ describe LightService::Organizer do
         .with(hash_including(:_aliases => { :foo => :bar }))
         .and_return(with_reducer)
 
-      organizer.do_stuff
+      organizer.call
     end
   end
 end

--- a/spec/sample/calculates_tax_spec.rb
+++ b/spec/sample/calculates_tax_spec.rb
@@ -26,7 +26,7 @@ describe CalculatesTax do
       .with(ctx)
       .and_return(ctx)
 
-    result = CalculatesTax.for_order(order)
+    result = CalculatesTax.call(order)
 
     expect(result).to eq(ctx)
   end

--- a/spec/sample/tax/calculates_tax.rb
+++ b/spec/sample/tax/calculates_tax.rb
@@ -1,7 +1,7 @@
 class CalculatesTax
   extend LightService::Organizer
 
-  def self.for_order(order)
+  def self.call(order)
     with(:order => order).reduce(
       LooksUpTaxPercentageAction,
       CalculatesOrderTaxAction,

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -19,7 +19,7 @@ module TestDoubles
 
   class AroundEachOrganizer
     extend LightService::Organizer
-    def self.add(action_arguments)
+    def self.call(action_arguments)
       with(action_arguments)
         .around_each(AroundEachLoggerHandler)
         .reduce([AddsTwoActionWithFetch])
@@ -41,7 +41,7 @@ module TestDoubles
   class AnOrganizer
     extend LightService::Organizer
 
-    def self.do_something(action_arguments)
+    def self.call(action_arguments)
       with(action_arguments).reduce([AnAction, AnotherAction])
     end
 
@@ -163,7 +163,7 @@ module TestDoubles
   class AdditionOrganizer
     extend LightService::Organizer
 
-    def self.add_numbers(number)
+    def self.call(number)
       with(:number => number).reduce(
         AddsOneAction,
         AddsTwoAction,


### PR DESCRIPTION
As we are getting closer to introduce Orchestrators, the naming standard will be this:

```
Orchestrators
  |-> run
  Organizers
     |-> call
     Actions
        |-> execute
```

It could take some practice of giving good names to Organizers, but
the method name should not be part of describing that. Also, this
convention will help the developers to figure out where an Orchestrator,
an Organizer, and Action is called.

This will go under version 0.7.