### PR TITLE
DRY up expects and promises key initializeation logic

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -15,13 +15,11 @@ module LightService
 
     module Macros
       def expects(*args)
-        @_expected_keys ||= []
-        @_expected_keys.concat(args)
+        expected_keys.concat(args)
       end
 
       def promises(*args)
-        @_promised_keys ||= []
-        @_promised_keys.concat(args)
+        promised_keys.concat(args)
       end
 
       def expected_keys


### PR DESCRIPTION
I noticed we have the `expected_keys` and `promised_keys` initialization
logic twice, removing the duplication with this commit.