### PR TITLE
Refactor KeyVerifiers

### DIFF
--- a/lib/light-service/context/key_verifier.rb
+++ b/lib/light-service/context/key_verifier.rb
@@ -8,13 +8,7 @@ module LightService
         @action = action
       end
 
-      def are_all_keys_in_context?(keys)
-        not_found_keys = keys_not_found(keys)
-        !not_found_keys.any?
-      end
-
-      def keys_not_found(keys)
-        keys ||= context.keys
+      def keys_missing_from_context(keys)
         keys - context.keys
       end
 
@@ -23,7 +17,7 @@ module LightService
       end
 
       def error_message
-        "#{type_name} #{format_keys(keys_not_found(keys))} " \
+        "#{type_name} #{format_keys(keys_missing_from_context(keys))} " \
         "to be in the context during #{action}"
       end
 
@@ -87,7 +81,7 @@ module LightService
       end
 
       def throw_error?
-        !are_all_keys_in_context?(keys)
+        keys_missing_from_context(keys).any?
       end
     end
 
@@ -105,7 +99,7 @@ module LightService
       end
 
       def throw_error?
-        !are_all_keys_in_context?(keys)
+        keys_missing_from_context(keys).any?
       end
     end
 

--- a/lib/light-service/context/key_verifier.rb
+++ b/lib/light-service/context/key_verifier.rb
@@ -33,13 +33,10 @@ module LightService
 
       def verify
         return context if context.failure?
+        return context unless throw_error?
 
-        if throw_error?
-          Configuration.logger.error error_message
-          raise error_to_throw, error_message
-        end
-
-        context
+        Configuration.logger.error error_message
+        raise error_to_throw, error_message
       end
 
       def self.verify_keys(context, action, &block)

--- a/lib/light-service/context/key_verifier.rb
+++ b/lib/light-service/context/key_verifier.rb
@@ -27,14 +27,14 @@ module LightService
         "to be in the context during #{action}"
       end
 
-      def throw_error_predicate(_keys)
+      def throw_error?
         raise NotImplementedError, 'Sorry, you have to override length'
       end
 
       def verify
         return context if context.failure?
 
-        if throw_error_predicate(keys)
+        if throw_error?
           Configuration.logger.error error_message
           raise error_to_throw, error_message
         end
@@ -67,7 +67,7 @@ module LightService
         ExpectedKeysNotUsedError
       end
 
-      def throw_error_predicate(keys)
+      def throw_error?
         keys.any?
       end
 
@@ -89,7 +89,7 @@ module LightService
         ExpectedKeysNotInContextError
       end
 
-      def throw_error_predicate(keys)
+      def throw_error?
         !are_all_keys_in_context?(keys)
       end
     end
@@ -107,7 +107,7 @@ module LightService
         PromisedKeysNotInContextError
       end
 
-      def throw_error_predicate(keys)
+      def throw_error?
         !are_all_keys_in_context?(keys)
       end
     end
@@ -130,7 +130,7 @@ module LightService
         ReservedKeysInContextError
       end
 
-      def throw_error_predicate(keys)
+      def throw_error?
         keys.any?
       end
 

--- a/lib/light-service/context/key_verifier.rb
+++ b/lib/light-service/context/key_verifier.rb
@@ -12,14 +12,12 @@ module LightService
         keys - context.keys
       end
 
-      def format_keys(keys)
-        keys.map { |k| ":#{k}" }.join(', ')
+      def formatted_keys
+        offending_keys.map { |k| ":#{k}" }.join(', ')
       end
 
       def error_message
-        "#{type_name} "\
-        "#{format_keys(keys_missing_from_context(offending_keys))} " \
-        "to be in the context during #{action}"
+        "#{type_name} #{formatted_keys} to be in the context during #{action}"
       end
 
       def throw_error?
@@ -60,8 +58,7 @@ module LightService
       end
 
       def error_message
-        "Expected keys [#{format_keys(offending_keys)}] to be used during "\
-        "#{action}"
+        "Expected keys [#{formatted_keys}] to be used during #{action}"
       end
     end
 
@@ -95,8 +92,8 @@ module LightService
 
     class ReservedKeysVerifier < KeyVerifier
       def error_message
-        "promised or expected keys cannot be a " \
-        "reserved key: [#{format_keys(offending_keys)}]"
+        "promised or expected keys cannot be a reserved key: "\
+        "[#{formatted_keys}]"
       end
 
       def offending_keys


### PR DESCRIPTION
This PR simplifies the verifiers used to check that expected keys exist, that expected keys are used and that promised keys are created.  It does a few things:

* Verifiers are expected to return a list of `offending_keys`.  If there are keys in the list, an error will be raised.
* A default formatting for `offending_keys` is provided, as is a default error message.
* An instance method `throw_error?` is used instead of `throw_error_predicate`.
* Duplicated code has been moved to the superclass, but a Verifier is free to override any necessary methods.