### PR TITLE
Make logging more efficient if it isn't turned on

### DIFF
--- a/lib/light-service/configuration.rb
+++ b/lib/light-service/configuration.rb
@@ -16,7 +16,7 @@ module LightService
 
       def _default_logger
         logger = Logger.new("/dev/null")
-        logger.level = Logger::INFO
+        logger.level = Logger::WARN
         logger
       end
     end

--- a/lib/light-service/organizer/with_reducer_log_decorator.rb
+++ b/lib/light-service/organizer/with_reducer_log_decorator.rb
@@ -17,8 +17,10 @@ module LightService
 
         decorated.with(data)
 
-        logger.info { "[LightService] -     keys in context: " \
-                      "#{extract_keys(decorated.context.keys)}" }
+        logger.info do
+          "[LightService] -     keys in context: " \
+          "#{extract_keys(decorated.context.keys)}"
+        end
         self
       end
 
@@ -48,13 +50,13 @@ module LightService
       private
 
       def write_log(action, context)
-        if logger.info?
-          logger.info("[LightService] - executing <#{action}>")
-          log_expects(action)
-          log_promises(action)
-          logger.info("[LightService] -     keys in context: "\
-                      "#{extract_keys(context.keys)}")
-        end
+        return unless logger.info?
+
+        logger.info("[LightService] - executing <#{action}>")
+        log_expects(action)
+        log_promises(action)
+        logger.info("[LightService] -     keys in context: "\
+                    "#{extract_keys(context.keys)}")
       end
 
       def log_expects(action)
@@ -90,13 +92,13 @@ module LightService
       end
 
       def write_skip_remaining_log(context, action)
-        if logger.info?
-          msg = "[LightService] - ;-) <#{action}> has decided " \
-                "to skip the rest of the actions"
-          logger.info(msg)
-          logger.info("[LightService] - context message: #{context.message}")
-          @logged = true
-        end
+        return unless logger.info?
+
+        msg = "[LightService] - ;-) <#{action}> has decided " \
+              "to skip the rest of the actions"
+        logger.info(msg)
+        logger.info("[LightService] - context message: #{context.message}")
+        @logged = true
       end
     end
   end

--- a/lib/light-service/organizer/with_reducer_log_decorator.rb
+++ b/lib/light-service/organizer/with_reducer_log_decorator.rb
@@ -13,12 +13,12 @@ module LightService
       end
 
       def with(data = {})
-        logger.info("[LightService] - calling organizer <#{organizer}>")
+        logger.info { "[LightService] - calling organizer <#{organizer}>" }
 
         decorated.with(data)
 
-        logger.info("[LightService] -     keys in context: " \
-                    "#{extract_keys(decorated.context.keys)}")
+        logger.info { "[LightService] -     keys in context: " \
+                      "#{extract_keys(decorated.context.keys)}" }
         self
       end
 
@@ -48,11 +48,13 @@ module LightService
       private
 
       def write_log(action, context)
-        logger.info("[LightService] - executing <#{action}>")
-        log_expects(action)
-        log_promises(action)
-        logger.info("[LightService] -     keys in context: "\
-                    "#{extract_keys(context.keys)}")
+        if logger.info?
+          logger.info("[LightService] - executing <#{action}>")
+          log_expects(action)
+          log_promises(action)
+          logger.info("[LightService] -     keys in context: "\
+                      "#{extract_keys(context.keys)}")
+        end
       end
 
       def log_expects(action)
@@ -88,11 +90,13 @@ module LightService
       end
 
       def write_skip_remaining_log(context, action)
-        msg = "[LightService] - ;-) <#{action}> has decided " \
-              "to skip the rest of the actions"
-        logger.info(msg)
-        logger.info("[LightService] - context message: #{context.message}")
-        @logged = true
+        if logger.info?
+          msg = "[LightService] - ;-) <#{action}> has decided " \
+                "to skip the rest of the actions"
+          logger.info(msg)
+          logger.info("[LightService] - context message: #{context.message}")
+          @logged = true
+        end
       end
     end
   end


### PR DESCRIPTION
The ruby logger class has two forms- one with method params, and one with a
block. They are different as the block form is lazy evaulated, and only
evaulated if the log level is actually enabled.

We can use this block form logger, as well as the `logger.info?` guard, to save
ourselves from building several log messages if we aren't actually going to
send or print them somewhere. This should have no effect whatsoever on the
contents of logs, it simply saves the overhead of string operations if we
aren't actually logging.

http://brian.pontarelli.com/2006/07/03/ruby-logging-and-performance/