### PR TITLE
Only pass default argument to Hash#fetch in context if no block given

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -139,8 +139,12 @@ module LightService
       return super(key)
     end
 
-    def fetch(key, default_or_block = nil)
-      self[key] ||= super(key, default_or_block)
+    def fetch(key, default = nil, &blk)
+      self[key] ||= if block_given?
+                      super(key, &blk)
+                    else
+                      super
+                    end
     end
 
     def inspect

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -162,6 +162,14 @@ RSpec.describe LightService::Context do
     expect(context[:foo]).to eq false
   end
 
+  it "allows a default value for #fetch" do
+    expect(context.fetch(:madeup, :default)).to eq(:default)
+  end
+
+  it "allows a default block value for #fetch" do
+    expect(context.fetch(:madeup) { :default }).to eq(:default)
+  end
+
   context "when aliases are included via .make" do
     let(:context) do
       LightService::Context.make(


### PR DESCRIPTION
Hash#fetch outputs a warning if the arg count is 2 and a block is given.

It's not possible to just pass a block without this change as the `key` and `default_or_block` arguments are always passed to the parent method.

Checking if there is a block and only passing the default if there is no block stops the warning message from showing.