### PR TITLE
No need to return when context fails

### DIFF
--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -149,13 +149,11 @@ module TestDoubles
     executed do |context|
       if context.milk == :very_hot
         context.fail!("Can't make a latte from a milk that's very hot!")
-        next context
       end
 
       if context.milk == :super_hot
         error_message = "Can't make a latte from a milk that's super hot!"
         context.fail_with_rollback!(error_message)
-        next context
       end
 
       context[:latte] = "#{context.coffee} - with lots of #{context.milk}"


### PR DESCRIPTION
The `ctx.fail!('error message')` returns the context implicitly, no need
to return from the calling code.