### PR TITLE
After_failing callback for orchestrators

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -8,7 +8,8 @@ module LightService
 
   # rubocop:disable ClassLength
   class Context < Hash
-    attr_accessor :message, :error_code, :current_action, :orchestrator_callbacks
+    attr_accessor :message, :error_code, :current_action,
+                  :orchestrator_callbacks
 
     def initialize(context = {},
                    outcome = Outcomes::SUCCESS,
@@ -86,11 +87,8 @@ module LightService
                                                             options)
       @error_code = error_code
       @outcome = Outcomes::FAILURE
-      unless @orchestrator_callbacks[:after_failing].nil?
-        @orchestrator_callbacks[:after_failing].each do |cb|
-          cb.call(self)
-        end
-      end
+
+      run_callbacks :after_failing
     end
 
     def fail_and_return!(*args)
@@ -169,6 +167,13 @@ module LightService
     def check_nil(value)
       return 'nil' unless value
       "'#{value}'"
+    end
+
+    def run_callbacks(symbol)
+      return if @orchestrator_callbacks[symbol].nil?
+      @orchestrator_callbacks[symbol].each do |cb|
+        cb.call(self)
+      end
     end
   end
   # rubocop:enable ClassLength

--- a/lib/light-service/orchestrator.rb
+++ b/lib/light-service/orchestrator.rb
@@ -87,10 +87,11 @@ module LightService
       end
 
       def after_failing(symbols)
-        symbols = [symbols] unless symbols.kind_of?(Array)
-        @context.orchestrator_callbacks[:after_failing] = symbols.map do |symbol|
-          method(symbol)
-        end
+        symbols = [symbols] unless symbols.is_a?(Array)
+        @context.orchestrator_callbacks[:after_failing] =
+          symbols.map do |symbol|
+            method(symbol)
+          end
         self
       end
 

--- a/lib/light-service/orchestrator.rb
+++ b/lib/light-service/orchestrator.rb
@@ -86,6 +86,14 @@ module LightService
         end
       end
 
+      def after_failing(symbols)
+        symbols = [symbols] unless symbols.kind_of?(Array)
+        @context.orchestrator_callbacks[:after_failing] = symbols.map do |symbol|
+          method(symbol)
+        end
+        self
+      end
+
       private
 
       def scoped_reduction(ctx, steps)

--- a/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
+++ b/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
@@ -2,11 +2,30 @@ require 'spec_helper'
 require 'test_doubles'
 
 describe LightService::Orchestrator do
+  class TestFailureError1 < StandardError
+  end
+  class TestFailureError2 < StandardError
+  end
+
   class TestReduce
     extend LightService::Orchestrator
 
     def self.run(context, steps)
       with(context).reduce(steps)
+    end
+
+    def self.run_with_after_fail(context, steps, after_fail_method_identifiers)
+      with(context).after_failing(after_fail_method_identifiers).reduce(steps)
+    end
+
+    def self.after_fail1(ctx)
+      if ctx.message == 'A failure has occured.'
+        raise TestFailureError1
+      end
+    end
+
+    def self.after_fail2(ctx)
+      raise TestFailureError2
     end
   end
 
@@ -29,6 +48,34 @@ describe LightService::Orchestrator do
 
     expect(result).not_to be_success
     expect(result.number).to eq(2)
+  end
+
+  it 'fails fast by skipping proceeding actions/organizers after failure, and runs the after_fail callback' do
+    expect do
+      TestReduce.run_with_after_fail({ :number => 0 }, [
+                                TestDoubles::AddTwoOrganizer,
+                                TestDoubles::FailureActionWithMessage
+                              ], :after_fail1)
+    end.to raise_error(TestFailureError1)
+  end
+
+  it 'fails fast by skipping proceeding actions/organizers after failure, and runs multiple after_fail callbacks' do
+    expect do
+      TestReduce.run_with_after_fail({ :number => 0 }, [
+                                TestDoubles::AddTwoOrganizer,
+                                TestDoubles::FailureAction
+                              ], [:after_fail1, :after_fail2])
+    end.to raise_error(TestFailureError2)
+  end
+
+  it 'does not run after_fail callbacks if orchestrator successful' do
+    result = TestReduce.run_with_after_fail({ :number => 0 }, [
+                              TestDoubles::AddTwoOrganizer,
+                              TestDoubles::AddOneAction
+                            ], [:after_fail1, :after_fail2])
+
+    expect(result).to be_success
+    expect(result.number).to eq(3)
   end
 
   it 'does not allow anything but actions and organizers' do

--- a/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
+++ b/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
@@ -19,12 +19,10 @@ describe LightService::Orchestrator do
     end
 
     def self.after_fail1(ctx)
-      if ctx.message == 'A failure has occured.'
-        raise TestFailureError1
-      end
+      raise TestFailureError1 if ctx.message == 'A failure has occured.'
     end
 
-    def self.after_fail2(ctx)
+    def self.after_fail2(_ctx)
       raise TestFailureError2
     end
   end
@@ -50,29 +48,29 @@ describe LightService::Orchestrator do
     expect(result.number).to eq(2)
   end
 
-  it 'fails fast by skipping proceeding actions/organizers after failure, and runs the after_fail callback' do
+  it 'fails fast and runs the after_fail callback' do
     expect do
       TestReduce.run_with_after_fail({ :number => 0 }, [
-                                TestDoubles::AddTwoOrganizer,
-                                TestDoubles::FailureActionWithMessage
-                              ], :after_fail1)
+                                       TestDoubles::AddTwoOrganizer,
+                                       TestDoubles::FailureActionWithMessage
+                                     ], :after_fail1)
     end.to raise_error(TestFailureError1)
   end
 
-  it 'fails fast by skipping proceeding actions/organizers after failure, and runs multiple after_fail callbacks' do
+  it 'fails fast and runs multiple after_fail callbacks' do
     expect do
       TestReduce.run_with_after_fail({ :number => 0 }, [
-                                TestDoubles::AddTwoOrganizer,
-                                TestDoubles::FailureAction
-                              ], [:after_fail1, :after_fail2])
+                                       TestDoubles::AddTwoOrganizer,
+                                       TestDoubles::FailureAction
+                                     ], %i[after_fail1 after_fail2])
     end.to raise_error(TestFailureError2)
   end
 
   it 'does not run after_fail callbacks if orchestrator successful' do
     result = TestReduce.run_with_after_fail({ :number => 0 }, [
-                              TestDoubles::AddTwoOrganizer,
-                              TestDoubles::AddOneAction
-                            ], [:after_fail1, :after_fail2])
+                                              TestDoubles::AddTwoOrganizer,
+                                              TestDoubles::AddOneAction
+                                            ], %i[after_fail1 after_fail2])
 
     expect(result).to be_success
     expect(result.number).to eq(3)

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -30,6 +30,13 @@ module TestDoubles
     executed(&:fail!)
   end
 
+  class FailureActionWithMessage
+    extend LightService::Action
+    executed do |ctx|
+      ctx.fail! 'A failure has occured.'
+    end
+  end
+
   class AddOneAction
     extend LightService::Action
     expects :number


### PR DESCRIPTION
To make my test failures more meaningful when asserting `result.success?`, I'd like to throw an error when `ctx.fail!` is called in my test environment. I believe this is best done by adding a callback/hook to an orchestrator that would run when the orchestrator fails.

This PR offers a possible implementation for it, but is open to discussion. It is significantly different from the proposals I had made in #127, because after better understanding how LightService is used, I feel it makes more sense to declare it in the line of code that defines what the orchestrator does, rather than the way Active Record does callbacks.

So, with this PR, it works like that:

```
class CalculatesTax
  extend LightService::Organizer

  def self.call(order)
    with(:order => order).after_failing(:foo, :bar).reduce(
        LooksUpTaxPercentageAction,
        CalculatesOrderTaxAction,
        ProvidesFreeShippingAction
      )
  end

  def self.foo(ctx)
    # Do something
  end

  def self.bar(ctx)
    # Do something
  end
end
```