### PR TITLE
Before/After Action Hooks

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -42,6 +42,7 @@ module LightService
             action_context.define_accessor_methods_for_keys(all_keys)
 
             catch(:jump_when_failed) do
+              call_before_action(action_context)
               yield(action_context)
             end
           end
@@ -69,6 +70,16 @@ module LightService
 
       def all_keys
         expected_keys + promised_keys
+      end
+
+      def call_before_action(context)
+        return unless context.keys.include?(:_before_action)
+
+        before_action_callbacks = context[:_before_action]
+
+        before_action_callbacks.each do |cb|
+          cb.call(context)
+        end
       end
     end
   end

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -44,6 +44,7 @@ module LightService
             catch(:jump_when_failed) do
               call_before_action(action_context)
               yield(action_context)
+              call_after_action(action_context)
             end
           end
         end
@@ -73,13 +74,21 @@ module LightService
       end
 
       def call_before_action(context)
-        return unless context.keys.include?(:_before_action)
+        invoke_callbacks(context[:_before_actions], context)
+      end
 
-        before_action_callbacks = context[:_before_action]
+      def call_after_action(context)
+        invoke_callbacks(context[:_after_actions], context)
+      end
 
-        before_action_callbacks.each do |cb|
+      def invoke_callbacks(callbacks, context)
+        return context unless callbacks
+
+        callbacks.each do |cb|
           cb.call(context)
         end
+
+        context
       end
     end
   end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -21,8 +21,13 @@ module LightService
         data[:_aliases] = @aliases if @aliases
 
         if @before_actions
-          data[:_before_action] = @before_actions.dup
+          data[:_before_actions] = @before_actions.dup
           @before_actions = nil
+        end
+
+        if @after_actions
+          data[:_after_actions] = @after_actions.dup
+          @after_actions = nil
         end
 
         WithReducerFactory.make(self).with(data)
@@ -64,6 +69,14 @@ module LightService
 
       def before_actions=(logic)
         @before_actions = logic
+      end
+
+      def after_actions(*logic)
+        self.after_actions = logic
+      end
+
+      def after_actions=(logic)
+        @after_actions = logic
       end
     end
   end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -19,6 +19,12 @@ module LightService
       def with(data = {})
         VerifyCallMethodExists.run(self, caller(1..1).first)
         data[:_aliases] = @aliases if @aliases
+
+        if @before_action_logic
+          data[:_before_action] = @before_action_logic
+          @before_action_logic = nil
+        end
+
         WithReducerFactory.make(self).with(data)
       end
 
@@ -50,6 +56,10 @@ module LightService
     module Macros
       def aliases(key_hash)
         @aliases = key_hash
+      end
+
+      def before_action=(logic)
+        @before_action_logic = logic
       end
     end
   end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -20,9 +20,9 @@ module LightService
         VerifyCallMethodExists.run(self, caller(1..1).first)
         data[:_aliases] = @aliases if @aliases
 
-        if @before_action_logic
-          data[:_before_action] = @before_action_logic.dup
-          @before_action_logic = nil
+        if @before_actions
+          data[:_before_action] = @before_actions.dup
+          @before_actions = nil
         end
 
         WithReducerFactory.make(self).with(data)
@@ -58,8 +58,12 @@ module LightService
         @aliases = key_hash
       end
 
-      def before_action=(logic)
-        @before_action_logic = logic
+      def before_actions(*logic)
+        self.before_actions = logic
+      end
+
+      def before_actions=(logic)
+        @before_actions = logic
       end
     end
   end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -21,7 +21,7 @@ module LightService
         data[:_aliases] = @aliases if @aliases
 
         if @before_action_logic
-          data[:_before_action] = @before_action_logic
+          data[:_before_action] = @before_action_logic.dup
           @before_action_logic = nil
         end
 

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -68,7 +68,7 @@ module LightService
       end
 
       def before_actions=(logic)
-        @before_actions = logic
+        @before_actions = [logic].flatten
       end
 
       def after_actions(*logic)
@@ -76,7 +76,7 @@ module LightService
       end
 
       def after_actions=(logic)
-        @after_actions = logic
+        @after_actions = [logic].flatten
       end
     end
   end

--- a/spec/acceptance/add_numbers_spec.rb
+++ b/spec/acceptance/add_numbers_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'test_doubles'
 
-describe TestDoubles::AdditionOrganizer do
-  it "Adds 1, 2 and 3 to the initial value of 1" do
+RSpec.describe TestDoubles::AdditionOrganizer do
+  it 'Adds 1, 2 and 3 to the initial value of 1' do
     result = TestDoubles::AdditionOrganizer.call(1)
-    number = result.fetch(:product)
+    number = result.fetch(:number)
 
     expect(number).to eq(7)
   end

--- a/spec/acceptance/after_actions_spec.rb
+++ b/spec/acceptance/after_actions_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'test_doubles'
+
+RSpec.describe 'Action after_actions' do
+  describe 'works with simple organizers - from outside' do
+    it 'can be used to inject code block before each action' do
+      TestDoubles::AdditionOrganizer.after_actions = [
+        lambda do |ctx|
+          ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
+        end
+      ]
+
+      result = TestDoubles::AdditionOrganizer.call(0)
+
+      expect(result.fetch(:number)).to eq(4)
+    end
+
+    it 'works with iterator' do
+      TestDoubles::TestIterate.after_actions = [
+        lambda do |ctx|
+          ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
+        end
+      ]
+
+      result = TestDoubles::TestIterate.call(:number => 0,
+                                             :counters => [1, 2, 3, 4])
+
+      expect(result).to be_success
+      expect(result.number).to eq(-4)
+    end
+  end
+
+  describe 'can be added to organizers declaratively' do
+    module AfterActions
+      class AdditionOrganizer
+        extend LightService::Organizer
+        after_actions (lambda do |ctx|
+                         if ctx.current_action == TestDoubles::AddsOneAction
+                           ctx.number -= 2
+                         end
+                       end),
+                      (lambda do |ctx|
+                         if ctx.current_action == TestDoubles::AddsThreeAction
+                           ctx.number -= 3
+                         end
+                       end)
+
+        def self.call(number)
+          with(:number => number).reduce(actions)
+        end
+
+        def self.actions
+          [
+            TestDoubles::AddsOneAction,
+            TestDoubles::AddsTwoAction,
+            TestDoubles::AddsThreeAction
+          ]
+        end
+      end
+    end
+
+    it 'accepts after_actions hook lambdas from organizer' do
+      result = AfterActions::AdditionOrganizer.call(0)
+
+      expect(result.fetch(:number)).to eq(1)
+    end
+  end
+end

--- a/spec/acceptance/after_actions_spec.rb
+++ b/spec/acceptance/after_actions_spec.rb
@@ -4,11 +4,10 @@ require 'test_doubles'
 RSpec.describe 'Action after_actions' do
   describe 'works with simple organizers - from outside' do
     it 'can be used to inject code block before each action' do
-      TestDoubles::AdditionOrganizer.after_actions = [
+      TestDoubles::AdditionOrganizer.after_actions =
         lambda do |ctx|
           ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
         end
-      ]
 
       result = TestDoubles::AdditionOrganizer.call(0)
 

--- a/spec/acceptance/before_actions_spec.rb
+++ b/spec/acceptance/before_actions_spec.rb
@@ -4,11 +4,10 @@ require 'test_doubles'
 RSpec.describe 'Action before_actions' do
   describe 'works with simple organizers - from outside' do
     it 'can be used to inject code block before each action' do
-      TestDoubles::AdditionOrganizer.before_actions = [
+      TestDoubles::AdditionOrganizer.before_actions =
         lambda do |ctx|
           ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
         end
-      ]
 
       result = TestDoubles::AdditionOrganizer.call(0)
 

--- a/spec/acceptance/before_actions_spec.rb
+++ b/spec/acceptance/before_actions_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'test_doubles'
 
-RSpec.describe 'Action before hooks' do
+RSpec.describe 'Action before_actions' do
   describe 'works with simple organizers - from outside' do
     it 'can be used to inject code block before each action' do
       TestDoubles::AdditionOrganizer.before_actions = [
@@ -30,7 +30,7 @@ RSpec.describe 'Action before hooks' do
     end
   end
 
-  describe 'can be added to the organizer' do
+  describe 'can be added to the organizers declaratively' do
     module BeforeHook
       class AdditionOrganizer
         extend LightService::Organizer

--- a/spec/acceptance/before_actions_spec.rb
+++ b/spec/acceptance/before_actions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Action before_actions' do
       expect(result.fetch(:number)).to eq(4)
     end
 
-    it 'Adds 1, 2 and 3 to the initial value of 1' do
+    it 'works with iterator' do
       TestDoubles::TestIterate.before_actions = [
         lambda do |ctx|
           ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
@@ -30,8 +30,8 @@ RSpec.describe 'Action before_actions' do
     end
   end
 
-  describe 'can be added to the organizers declaratively' do
-    module BeforeHook
+  describe 'can be added to organizers declaratively' do
+    module BeforeActions
       class AdditionOrganizer
         extend LightService::Organizer
         before_actions (lambda do |ctx|
@@ -60,7 +60,7 @@ RSpec.describe 'Action before_actions' do
     end
 
     it 'accepts before_actions hook lambdas from organizer' do
-      result = BeforeHook::AdditionOrganizer.call(0)
+      result = BeforeActions::AdditionOrganizer.call(0)
 
       expect(result.fetch(:number)).to eq(1)
     end

--- a/spec/acceptance/before_hook_spec.rb
+++ b/spec/acceptance/before_hook_spec.rb
@@ -2,28 +2,72 @@ require 'spec_helper'
 require 'test_doubles'
 
 RSpec.describe 'Action before hooks' do
-  it 'can be used to inject code block before each action' do
-    TestDoubles::AdditionOrganizer.before_action = [
-      lambda do |ctx|
-        ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
-      end
-    ]
+  describe 'works with simple organizers' do
+    it 'can be used to inject code block before each action' do
+      TestDoubles::AdditionOrganizer.before_action = [
+        lambda do |ctx|
+          ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
+        end
+      ]
 
-    result = TestDoubles::AdditionOrganizer.call(0)
+      result = TestDoubles::AdditionOrganizer.call(0)
 
-    expect(result.fetch(:number)).to eq(4)
+      expect(result.fetch(:number)).to eq(4)
+    end
+
+    it 'Adds 1, 2 and 3 to the initial value of 1' do
+      TestDoubles::TestIterate.before_action = [
+        lambda do |ctx|
+          ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
+        end
+      ]
+
+      result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
+
+      expect(result).to be_success
+      expect(result.number).to eq(3)
+    end
   end
 
-  it 'Adds 1, 2 and 3 to the initial value of 1' do
-    TestDoubles::TestIterate.before_action = [
-      lambda do |ctx|
-        ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
+  describe 'works with callbacks' do
+    it 'can interact with actions from the outside' do
+      TestDoubles::TestWithCallback.before_action = [
+        lambda do |ctx|
+          if ctx.current_action == TestDoubles::AddToTotalAction
+            ctx.total -= 1000
+          end
+        end
+      ]
+      result = TestDoubles::TestWithCallback.call
+
+      expect(result.counter).to eq(3)
+      expect(result.total).to eq(-2994)
+    end
+  end
+
+  describe 'can halt all execution with a raised error' do
+    it 'does not call the rest of the callback steps' do
+      class SkipContextError < StandardError
+        attr_reader :ctx
+
+        def initialize(msg, ctx)
+          @ctx = ctx
+          super(msg)
+        end
       end
-    ]
-
-    result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
-
-    expect(result).to be_success
-    expect(result.number).to eq(3)
+      TestDoubles::TestWithCallback.before_action = [
+        lambda do |ctx|
+          if ctx.current_action == TestDoubles::IncrementCountAction
+            ctx.total -= 1000
+            raise SkipContextError.new("stop context now", ctx)
+          end
+        end
+      ]
+      begin
+        TestDoubles::TestWithCallback.call
+      rescue SkipContextError => e
+        expect(e.ctx).not_to be_empty
+      end
+    end
   end
 end

--- a/spec/acceptance/before_hook_spec.rb
+++ b/spec/acceptance/before_hook_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe 'Action before hooks' do
         end
       ]
 
-      result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
+      result = TestDoubles::TestIterate.call(:number => 0,
+                                             :counters => [1, 2, 3, 4])
 
       expect(result).to be_success
-      expect(result.number).to eq(3)
+      expect(result.number).to eq(-4)
     end
   end
 

--- a/spec/acceptance/before_hook_spec.rb
+++ b/spec/acceptance/before_hook_spec.rb
@@ -2,18 +2,6 @@ require 'spec_helper'
 require 'test_doubles'
 
 RSpec.describe 'Action before hooks' do
-  module BeforeHooks
-    class TestIterate
-      extend LightService::Organizer
-
-      def self.call(context)
-        with(context)
-          .reduce([iterate(:numbers,
-                           [TestDoubles::AddsOneAction])])
-      end
-    end
-  end
-
   it 'can be used to inject code block before each action' do
     TestDoubles::AdditionOrganizer.before_action = [
       lambda do |ctx|
@@ -27,13 +15,13 @@ RSpec.describe 'Action before hooks' do
   end
 
   it 'Adds 1, 2 and 3 to the initial value of 1' do
-    BeforeHooks::TestIterate.before_action = [
+    TestDoubles::TestIterate.before_action = [
       lambda do |ctx|
         ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
       end
     ]
 
-    result = BeforeHooks::TestIterate.call(:numbers => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
 
     expect(result).to be_success
     expect(result.number).to eq(3)

--- a/spec/acceptance/before_hook_spec.rb
+++ b/spec/acceptance/before_hook_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'test_doubles'
+
+RSpec.describe 'Action before hooks' do
+  module BeforeHooks
+    class TestIterate
+      extend LightService::Organizer
+
+      def self.call(context)
+        with(context)
+          .reduce([iterate(:numbers,
+                           [TestDoubles::AddsOneAction])])
+      end
+    end
+  end
+
+  it 'can be used to inject code block before each action' do
+    TestDoubles::AdditionOrganizer.before_action = [
+      lambda do |ctx|
+        ctx.number -= 2 if ctx.current_action == TestDoubles::AddsThreeAction
+      end
+    ]
+
+    result = TestDoubles::AdditionOrganizer.call(0)
+
+    expect(result.fetch(:number)).to eq(4)
+  end
+
+  it 'Adds 1, 2 and 3 to the initial value of 1' do
+    BeforeHooks::TestIterate.before_action = [
+      lambda do |ctx|
+        ctx.number -= 2 if ctx.current_action == TestDoubles::AddsOneAction
+      end
+    ]
+
+    result = BeforeHooks::TestIterate.call(:numbers => [1, 2, 3, 4])
+
+    expect(result).to be_success
+    expect(result.number).to eq(3)
+  end
+end

--- a/spec/acceptance/orchestrator/context_failure_and_skipping_spec.rb
+++ b/spec/acceptance/orchestrator/context_failure_and_skipping_spec.rb
@@ -10,18 +10,18 @@ describe LightService::Orchestrator do
       with(:number => 1).reduce([
                                   TestDoubles::SkipAllAction,
                                   reduce_until(->(ctx) { ctx.number == 3 },
-                                               TestDoubles::AddOneAction)
+                                               TestDoubles::AddsOneAction)
                                 ])
     end
 
     def self.run_skip_after
       with(:number => 1).reduce([
-                                  TestDoubles::AddOneAction,
+                                  TestDoubles::AddsOneAction,
                                   reduce_until(->(ctx) { ctx.number == 3 }, [
-                                                 TestDoubles::AddOneAction
+                                                 TestDoubles::AddsOneAction
                                                ]),
                                   TestDoubles::SkipAllAction,
-                                  TestDoubles::AddOneAction
+                                  TestDoubles::AddsOneAction
                                 ])
     end
 
@@ -29,8 +29,8 @@ describe LightService::Orchestrator do
       with(:number => 1).reduce([
                                   TestDoubles::FailureAction,
                                   reduce_until(->(ctx) { ctx[:number] == 3 },
-                                               TestDoubles::AddOneAction),
-                                  TestDoubles::AddOneAction
+                                               TestDoubles::AddsOneAction),
+                                  TestDoubles::AddsOneAction
                                 ])
     end
   end

--- a/spec/acceptance/orchestrator/execute_spec.rb
+++ b/spec/acceptance/orchestrator/execute_spec.rb
@@ -13,10 +13,10 @@ describe LightService::Orchestrator do
 
     def self.steps
       [
-        TestDoubles::AddOneAction,
+        TestDoubles::AddsOneAction,
         execute(->(ctx) { ctx.number += 1 }),
         execute(->(ctx) { ctx[:something] = 'hello' }),
-        TestDoubles::AddOneAction
+        TestDoubles::AddsOneAction
       ]
     end
   end

--- a/spec/acceptance/orchestrator/iterate_spec.rb
+++ b/spec/acceptance/orchestrator/iterate_spec.rb
@@ -10,14 +10,14 @@ describe LightService::Orchestrator do
     def self.run(context)
       with(context).reduce([
                              iterate(:numbers, [
-                                       TestDoubles::AddOneAction
+                                       TestDoubles::AddsOneAction
                                      ])
                            ])
     end
 
     def self.run_single(context)
       with(context).reduce([
-                             iterate(:numbers, TestDoubles::AddOneAction)
+                             iterate(:numbers, TestDoubles::AddsOneAction)
                            ])
     end
   end

--- a/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
+++ b/spec/acceptance/orchestrator/organizer_action_combination_spec.rb
@@ -15,7 +15,7 @@ describe LightService::Orchestrator do
   it 'responds to both actions and organizers' do
     result = OrchestratorTestReduce.run({ :number => 0 }, [
                                           TestDoubles::AddTwoOrganizer,
-                                          TestDoubles::AddOneAction
+                                          TestDoubles::AddsOneAction
                                         ])
 
     expect(result).to be_success
@@ -26,7 +26,7 @@ describe LightService::Orchestrator do
     result = OrchestratorTestReduce.run({ :number => 0 }, [
                                           TestDoubles::AddTwoOrganizer,
                                           TestDoubles::FailureAction,
-                                          TestDoubles::AddOneAction
+                                          TestDoubles::AddsOneAction
                                         ])
 
     expect(result).not_to be_success

--- a/spec/acceptance/orchestrator/reduce_if_spec.rb
+++ b/spec/acceptance/orchestrator/reduce_if_spec.rb
@@ -13,9 +13,9 @@ describe LightService::Orchestrator do
 
     def self.steps
       [
-        TestDoubles::AddOneAction,
+        TestDoubles::AddsOneAction,
         reduce_if(->(ctx) { ctx.number == 1 },
-                  TestDoubles::AddOneAction)
+                  TestDoubles::AddsOneAction)
       ]
     end
   end

--- a/spec/acceptance/orchestrator/reduce_until_spec.rb
+++ b/spec/acceptance/orchestrator/reduce_until_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LightService::Orchestrator do
     def self.steps
       [
         reduce_until(->(ctx) { ctx.number == 3 },
-                     TestDoubles::AddOneAction)
+                     TestDoubles::AddsOneAction)
       ]
     end
   end

--- a/spec/acceptance/organizer/around_each_with_reduce_if_spec.rb
+++ b/spec/acceptance/organizer/around_each_with_reduce_if_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe LightService::Organizer do
 
     def self.actions
       [
-        TestDoubles::AddOneAction,
+        TestDoubles::AddsOneAction,
         reduce_if(->(ctx) { ctx.number == 1 },
-                  TestDoubles::AddOneAction)
+                  TestDoubles::AddsOneAction)
       ]
     end
   end
@@ -29,11 +29,11 @@ RSpec.describe LightService::Organizer do
     expect(result.fetch(:number)).to eq(2)
     expect(result[:logger].logs).to eq(
       [{
-        :action => TestDoubles::AddOneAction,
+        :action => TestDoubles::AddsOneAction,
         :before => 0,
         :after => 1
       }, {
-        :action => TestDoubles::AddOneAction,
+        :action => TestDoubles::AddsOneAction,
         :before => 1,
         :after => 2
       }]

--- a/spec/acceptance/organizer/context_failure_and_skipping_spec.rb
+++ b/spec/acceptance/organizer/context_failure_and_skipping_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LightService::Organizer do
         .reduce([
                   TestDoubles::SkipAllAction,
                   reduce_until(->(ctx) { ctx.number == 3 },
-                               TestDoubles::AddOneAction)
+                               TestDoubles::AddsOneAction)
                 ])
     end
   end
@@ -19,12 +19,12 @@ RSpec.describe LightService::Organizer do
     def self.call
       with(:number => 1)
         .reduce([
-                  TestDoubles::AddOneAction,
+                  TestDoubles::AddsOneAction,
                   reduce_until(->(ctx) { ctx.number == 3 }, [
-                                 TestDoubles::AddOneAction
+                                 TestDoubles::AddsOneAction
                                ]),
                   TestDoubles::SkipAllAction,
-                  TestDoubles::AddOneAction
+                  TestDoubles::AddsOneAction
                 ])
     end
   end
@@ -36,8 +36,8 @@ RSpec.describe LightService::Organizer do
         .reduce([
                   TestDoubles::FailureAction,
                   reduce_until(->(ctx) { ctx[:number] == 3 },
-                               TestDoubles::AddOneAction),
-                  TestDoubles::AddOneAction
+                               TestDoubles::AddsOneAction),
+                  TestDoubles::AddsOneAction
                 ])
     end
   end

--- a/spec/acceptance/organizer/execute_spec.rb
+++ b/spec/acceptance/organizer/execute_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe LightService::Organizer do
 
     def self.steps
       [
-        TestDoubles::AddOneAction,
+        TestDoubles::AddsOneAction,
         execute(->(ctx) { ctx.number += 1 }),
         execute(->(ctx) { ctx[:something] = 'hello' }),
-        TestDoubles::AddOneAction
+        TestDoubles::AddsOneAction
       ]
     end
   end

--- a/spec/acceptance/organizer/iterate_spec.rb
+++ b/spec/acceptance/organizer/iterate_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe LightService::Organizer do
   let(:empty_context) { LightService::Context.make }
 
   it 'reduces each item of a collection and singularizes the collection key' do
-    result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call(:number => 1,
+                                           :counters => [1, 2, 3, 4])
 
     expect(result).to be_success
     expect(result.number).to eq(5)
   end
 
   it 'accepts a single action or organizer' do
-    result = TestDoubles::TestIterate.call_single(:numbers => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call_single(:number => 1,
+                                                  :counters => [1, 2, 3, 4])
 
     expect(result).to be_success
     expect(result.number).to eq(5)

--- a/spec/acceptance/organizer/iterate_spec.rb
+++ b/spec/acceptance/organizer/iterate_spec.rb
@@ -2,33 +2,17 @@ require 'spec_helper'
 require 'test_doubles'
 
 RSpec.describe LightService::Organizer do
-  class TestIterate
-    extend LightService::Organizer
-
-    def self.call(context)
-      with(context)
-        .reduce([iterate(:numbers,
-                         [TestDoubles::AddOneAction])])
-    end
-
-    def self.call_single(context)
-      with(context)
-        .reduce([iterate(:numbers,
-                         TestDoubles::AddOneAction)])
-    end
-  end
-
   let(:empty_context) { LightService::Context.make }
 
   it 'reduces each item of a collection and singularizes the collection key' do
-    result = TestIterate.call(:numbers => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call(:numbers => [1, 2, 3, 4])
 
     expect(result).to be_success
     expect(result.number).to eq(5)
   end
 
   it 'accepts a single action or organizer' do
-    result = TestIterate.call_single(:numbers => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call_single(:numbers => [1, 2, 3, 4])
 
     expect(result).to be_success
     expect(result.number).to eq(5)
@@ -37,7 +21,7 @@ RSpec.describe LightService::Organizer do
   it 'will not iterate over a failed context' do
     empty_context.fail!('Something bad happened')
 
-    result = TestIterate.call(empty_context)
+    result = TestDoubles::TestIterate.call(empty_context)
 
     expect(result).to be_failure
   end
@@ -45,7 +29,7 @@ RSpec.describe LightService::Organizer do
   it 'does not iterate over a skipped context' do
     empty_context.skip_remaining!('No more needed')
 
-    result = TestIterate.call(empty_context)
+    result = TestDoubles::TestIterate.call(empty_context)
     expect(result).to be_success
   end
 end

--- a/spec/acceptance/organizer/reduce_if_spec.rb
+++ b/spec/acceptance/organizer/reduce_if_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe LightService::Organizer do
 
     def self.actions
       [
-        TestDoubles::AddOneAction,
+        TestDoubles::AddsOneAction,
         reduce_if(->(ctx) { ctx.number == 1 },
-                  TestDoubles::AddOneAction)
+                  TestDoubles::AddsOneAction)
       ]
     end
   end

--- a/spec/acceptance/organizer/reduce_until_spec.rb
+++ b/spec/acceptance/organizer/reduce_until_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LightService::Organizer do
     def self.actions
       [
         reduce_until(->(ctx) { ctx.number == 3 },
-                     TestDoubles::AddOneAction)
+                     TestDoubles::AddsOneAction)
       ]
     end
   end

--- a/spec/acceptance/organizer/with_callback_spec.rb
+++ b/spec/acceptance/organizer/with_callback_spec.rb
@@ -63,10 +63,20 @@ RSpec.describe LightService::Organizer do
 
   describe 'a simple case with a single callback' do
     it 'calls the actions defined with callback' do
+      TestWithCallback.before_action = [
+        lambda do |ctx|
+          ctx.total -= 1000 if ctx.current_action == AddToTotalAction
+        end
+      ]
       result = TestWithCallback.call
 
       expect(result.counter).to eq(3)
-      expect(result.total).to eq(6)
+      expect(result.total).to eq(-2994)
+    end
+  end
+
+  describe 'before_action' do
+    it 'can interact with actions from the outside' do
     end
   end
 

--- a/spec/acceptance/organizer/with_callback_spec.rb
+++ b/spec/acceptance/organizer/with_callback_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe LightService::Organizer do
         end
       ]
       begin
-        result = TestWithCallback.call
+        TestWithCallback.call
       rescue SkipContextError => e
         expect(e.ctx).not_to be_empty
       end

--- a/spec/sample/calculates_tax_spec.rb
+++ b/spec/sample/calculates_tax_spec.rb
@@ -6,10 +6,7 @@ require_relative 'tax/provides_free_shipping_action'
 
 describe CalculatesTax do
   let(:order) { double('order') }
-  let(:ctx) do
-    double('ctx', :keys => [:user],
-                  :failure? => false, :skip_remaining? => false)
-  end
+  let(:ctx) { LightService::Context.make(:user => nil) }
 
   it "calls the actions in order" do
     allow(LightService::Context).to receive(:make)

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -256,10 +256,9 @@ module TestDoubles
   class AddsThreeAction
     extend LightService::Action
     expects :number
-    promises :product
 
     executed do |context|
-      context.product = context.number + 3
+      context.number += 3
     end
   end
 

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -335,13 +335,13 @@ module TestDoubles
 
     def self.call(context)
       with(context)
-        .reduce([iterate(:numbers,
+        .reduce([iterate(:counters,
                          [TestDoubles::AddsOneAction])])
     end
 
     def self.call_single(context)
       with(context)
-        .reduce([iterate(:numbers,
+        .reduce([iterate(:counters,
                          TestDoubles::AddsOneAction)])
     end
   end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -345,4 +345,63 @@ module TestDoubles
                          TestDoubles::AddsOneAction)])
     end
   end
+
+  class TestWithCallback
+    extend LightService::Organizer
+
+    def self.call(context = {})
+      with(context).reduce(actions)
+    end
+
+    def self.actions
+      [
+        SetUpContextAction,
+        with_callback(IterateCollectionAction,
+                      [IncrementCountAction,
+                       AddToTotalAction])
+      ]
+    end
+  end
+
+  class SetUpContextAction
+    extend LightService::Action
+    promises :numbers, :counter, :total
+
+    executed do |ctx|
+      ctx.numbers = [1, 2, 3]
+      ctx.counter = 0
+      ctx.total = 0
+    end
+  end
+
+  class IterateCollectionAction
+    extend LightService::Action
+    expects :numbers, :callback
+    promises :number
+
+    executed do |ctx|
+      ctx.numbers.each do |number|
+        ctx.number = number
+        ctx.callback.call(ctx)
+      end
+    end
+  end
+
+  class IncrementCountAction
+    extend LightService::Action
+    expects :counter
+
+    executed do |ctx|
+      ctx.counter = ctx.counter + 1
+    end
+  end
+
+  class AddToTotalAction
+    extend LightService::Action
+    expects :number, :total
+
+    executed do |ctx|
+      ctx.total += ctx.number
+    end
+  end
 end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -30,21 +30,10 @@ module TestDoubles
     executed(&:fail!)
   end
 
-  class AddOneAction
-    extend LightService::Action
-    expects :number
-    promises :number
-
-    executed do |ctx|
-      ctx.number += 1
-      ctx.message = 'Added 1'
-    end
-  end
-
   class AddTwoOrganizer
     extend LightService::Organizer
     def self.call(context)
-      with(context).reduce([AddOneAction, AddOneAction])
+      with(context).reduce([AddsOneAction, AddsOneAction])
     end
   end
 
@@ -339,5 +328,21 @@ module TestDoubles
     extend LightService::Action
 
     executed { |_ctx| }
+  end
+
+  class TestIterate
+    extend LightService::Organizer
+
+    def self.call(context)
+      with(context)
+        .reduce([iterate(:numbers,
+                         [TestDoubles::AddsOneAction])])
+    end
+
+    def self.call_single(context)
+      with(context)
+        .reduce([iterate(:numbers,
+                         TestDoubles::AddsOneAction)])
+    end
   end
 end


### PR DESCRIPTION
As we used LS for more and more complex workflows (yeah, orchestrator functionality was born), we had to add instrumentation or custom logic before/after some or all actions.

I really liked [AOP concepts](https://en.wikipedia.org/wiki/Aspect-oriented_programming) back in the early 2000s, the idea of injecting custom code (almost like a plug-in interface) fascinated me.

This PR introduces the `before_actions` and `after_actions` hooks in LightService Organizers. These custom hooks at the Organizer level and they fire (if provided) before and after each action. They are great for instrumenting your code, yet you don't have to clutter the business logic with instrumentation.

Consider this code:

```ruby
class Organizer
  extend LightService::Organizer

  def call(ctx)
    with(ctx).reduce(actions)
  end

  def actions
    OneAction,
    TwoAction,
    ThreeAction
  end
end

class TwoAction
  extend LightService::Action
  expects :user, :logger

  executed do |ctx|
    # Logging information
    if ctx.user.role == 'admin'
       ctx.logger.info('admin is doing something')
    end

    ctx.user.do_something
  end
end
```

Note how the logging information is blurring the actual business logic.

You could now do this:

```ruby
Organizer.before_actions = 
  lambda do |ctx|
    if ctx.current_action == TwoAction
      return unless ctx.user.role == 'admin'
      ctx.logger.info('admin is doing something')
    end
  end

class TwoAction
  extend LightService::Action
  expects :user, :logger

  executed do |ctx|
    ctx.user.do_something
  end
end
```

Look, how the instrumentation logic has been decoupled from business logic.

The same is true for `after_actions`.

README update will be attached to this PR.