### PR TITLE
Remove extra argument from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ Check out this example:
 
 ```ruby
 class LogDuration
-  def self.call(action, context)
+  def self.call(context)
     start_time = Time.now
     result = yield
     duration = Time.now - start_time
     LightService::Configuration.logger.info(
-      :action   => action,
+      :action   => context.current_action,
       :duration => duration
     )
 


### PR DESCRIPTION
Passing `action` as a separate parameter causes an argument error because around_each expects only one argument.

See also: https://github.com/adomokos/light-service/blob/a207d17296d9ff995e39ddeb12ed039159a11606/spec/test_doubles.rb#L54