### PR TITLE
Organizers call each action with the same context

### DIFF
--- a/lib/light-service/organizer/with_reducer.rb
+++ b/lib/light-service/organizer/with_reducer.rb
@@ -25,7 +25,7 @@ module LightService
         raise "No action(s) were provided" if actions.empty?
         actions.flatten!
 
-        actions.reduce(context) do |current_context, action|
+        actions.each_with_object(context) do |action, current_context|
           begin
             result = invoke_action(current_context, action)
           rescue FailWithRollbackError

--- a/lib/light-service/organizer/with_reducer.rb
+++ b/lib/light-service/organizer/with_reducer.rb
@@ -27,9 +27,9 @@ module LightService
 
         actions.each_with_object(context) do |action, current_context|
           begin
-            result = invoke_action(current_context, action)
+            invoke_action(current_context, action)
           rescue FailWithRollbackError
-            result = reduce_rollback(actions)
+            reduce_rollback(actions)
           ensure
             # For logging
             yield(current_context, action) if block_given?

--- a/lib/light-service/organizer/with_reducer.rb
+++ b/lib/light-service/organizer/with_reducer.rb
@@ -34,8 +34,6 @@ module LightService
             # For logging
             yield(current_context, action) if block_given?
           end
-
-          result
         end
       end
 

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -44,20 +44,6 @@ describe LightService::Organizer do
     end
   end
 
-  context "when no starting context is specified" do
-    it "creates one implicitly" do
-      expect(TestDoubles::AnAction).to receive(:execute)
-        .with({})
-        .and_return(ctx)
-      expect(TestDoubles::AnotherAction).to receive(:execute)
-        .with(ctx)
-        .and_return(ctx)
-
-      expect { TestDoubles::AnOrganizer.do_something_with_no_starting_context }
-        .not_to raise_error
-    end
-  end
-
   context "when aliases are declared" do
     let(:organizer) do
       Class.new do

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -69,4 +69,17 @@ describe LightService::Organizer do
       organizer.call
     end
   end
+
+  context "when an organizer is nested within another" do
+    it "Does not raise an error" do
+      expect { TestDoubles::NestingOrganizer.call(ctx) }
+        .to_not raise_error
+    end
+
+    it "adds :foo and :bar to the context" do
+      TestDoubles::NestingOrganizer.call(ctx)
+      expect(ctx[:foo]).to eq([1, 2, 3])
+      expect(ctx[:bar]).to eq(ctx[:foo])
+    end
+  end
 end

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -70,16 +70,21 @@ describe LightService::Organizer do
     end
   end
 
-  context "when an organizer is nested within another" do
-    it "Does not raise an error" do
-      expect { TestDoubles::NestingOrganizer.call(ctx) }
-        .to_not raise_error
+  context "when an organizer is nested and reduced within another" do
+    let(:reduced) { TestDoubles::NestingOrganizer.call(ctx) }
+
+    it "reduces an organizer which returns something" do
+      expect(TestDoubles::ReturningOrganizer.call(ctx)).to eq([1, 2, 3])
     end
 
     it "adds :foo and :bar to the context" do
-      TestDoubles::NestingOrganizer.call(ctx)
+      reduced
       expect(ctx[:foo]).to eq([1, 2, 3])
       expect(ctx[:bar]).to eq(ctx[:foo])
+    end
+
+    it "returns the context" do
+      expect(reduced).to eq(ctx)
     end
   end
 end

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -72,9 +72,12 @@ describe LightService::Organizer do
 
   context "when an organizer is nested and reduced within another" do
     let(:reduced) { TestDoubles::NestingOrganizer.call(ctx) }
+    let(:organizer_result) do
+      TestDoubles::NotExplicitlyReturningContextOrganizer.call(ctx)
+    end
 
     it "reduces an organizer which returns something" do
-      expect(TestDoubles::ReturningOrganizer.call(ctx)).to eq([1, 2, 3])
+      expect(organizer_result).to eq([1, 2, 3])
     end
 
     it "adds :foo and :bar to the context" do

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -102,6 +102,32 @@ module TestDoubles
     end
   end
 
+  class NestedOrganizer
+    extend LightService::Organizer
+
+    def self.call(context)
+      context[:foo] = [1, 2, 3]
+    end
+  end
+
+  class NestingOrganizer
+    extend LightService::Organizer
+
+    def self.call(context)
+      with(context).reduce([NestedOrganizer, NestedAction])
+    end
+  end
+
+  class NestedAction
+    extend LightService::Action
+
+    expects :foo
+
+    executed do |context|
+      context[:bar] = context.foo
+    end
+  end
+
   class MakesTeaWithMilkAction
     extend LightService::Action
     expects :tea, :milk

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -114,7 +114,11 @@ module TestDoubles
     extend LightService::Organizer
 
     def self.call(context)
-      with(context).reduce([NotExplicitlyReturningContextOrganizer, NestedAction])
+      with(context).reduce(actions)
+    end
+
+    def self.actions
+      [NotExplicitlyReturningContextOrganizer, NestedAction]
     end
   end
 

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -102,7 +102,7 @@ module TestDoubles
     end
   end
 
-  class ReturningOrganizer
+  class NotExplicitlyReturningContextOrganizer
     extend LightService::Organizer
 
     def self.call(context)
@@ -114,7 +114,7 @@ module TestDoubles
     extend LightService::Organizer
 
     def self.call(context)
-      with(context).reduce([ReturningOrganizer, NestedAction])
+      with(context).reduce([NotExplicitlyReturningContextOrganizer, NestedAction])
     end
   end
 

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -102,7 +102,7 @@ module TestDoubles
     end
   end
 
-  class NestedOrganizer
+  class ReturningOrganizer
     extend LightService::Organizer
 
     def self.call(context)
@@ -114,7 +114,7 @@ module TestDoubles
     extend LightService::Organizer
 
     def self.call(context)
-      with(context).reduce([NestedOrganizer, NestedAction])
+      with(context).reduce([ReturningOrganizer, NestedAction])
     end
   end
 


### PR DESCRIPTION
Rather than passing the return of each action call to the subsequent action, organizers now call each action with the same context, allowing actions to mutate the same context action.

Am mainly opening this up for discussion as this _feels_ like a pretty fundamentally breaking change.

The issue this solves for is when an organizer is within another organizer as an action the action proceeding this organizer will be called with the return from `call` rather than the context object. This will of course then fail because the action is being called with something other than a `LightService::Context`.