### PR TITLE
Gemnasium is no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://img.shields.io/gem/v/light-service.svg)](https://rubygems.org/gems/light-service)
 [![Build Status](https://secure.travis-ci.org/adomokos/light-service.png)](http://travis-ci.org/adomokos/light-service)
 [![Code Climate](https://codeclimate.com/github/adomokos/light-service.png)](https://codeclimate.com/github/adomokos/light-service)
-[![Dependency Status](https://beta.gemnasium.com/badges/github.com/adomokos/light-service.svg)](https://beta.gemnasium.com/projects/github.com/adomokos/light-service)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](http://opensource.org/licenses/MIT)
 
 <br><br>


### PR DESCRIPTION
```
Why is Gemnasium.com closed? 
Gemnasium has been acquired by GitLab in January 2018. Since May 15, 2018, the services provided 
by Gemnasium are no longer available. The team behind Gemnasium has joined GitLab as the new 
Security Products team and is working on a wider range of tools than just Dependency Scanning: 
SAST, DAST, Container Scanning and more. If you want to continue monitoring your dependencies, 
see the Migrating to GitLab section below.
```

https://docs.gitlab.com/ee/user/project/import/gemnasium.html