### PR TITLE
Allow fail_and_return to receive error_code option

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@ A brief list of new features and changes introduced with the specified version.
 
 ### Unreleased
 * [Per organizer logger](https://github.com/adomokos/light-service/pull/162)
-* [Fix 'fail_and_return!' not accepting 'error_code' option](https://github.com/adomokos/light-service/issues/154)
+* [Fix 'fail_and_return!' not accepting 'error_code' option](https://github.com/adomokos/light-service/pull/168)
 
 ### 0.11.0
 * [Switch to 'each_with_object' in WithReducer](https://github.com/adomokos/light-service/pull/149).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@ A brief list of new features and changes introduced with the specified version.
 
 ### Unreleased
 * [Per organizer logger](https://github.com/adomokos/light-service/pull/162)
+* [Fix 'fail_and_return!' not accepting 'error_code' option](https://github.com/adomokos/light-service/issues/154)
 
 ### 0.11.0
 * [Switch to 'each_with_object' in WithReducer](https://github.com/adomokos/light-service/pull/149).

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -88,7 +88,7 @@ module LightService
 
     def fail_and_return!(*args)
       fail!(*args)
-      throw(:jump_when_failed, *args)
+      throw(:jump_when_failed)
     end
 
     def fail_with_rollback!(message = nil, error_code = nil)

--- a/spec/acceptance/fail_spec.rb
+++ b/spec/acceptance/fail_spec.rb
@@ -23,4 +23,28 @@ RSpec.describe "fail_and_return!" do
       expect(result.two).to be_nil
     end
   end
+
+  describe "accepts error_code option" do
+    class FailAndReturnWithErrorCodeAction
+      extend LightService::Action
+      promises :one, :two
+
+      executed do |ctx|
+        ctx.one = 1
+        # Have to set it in Context
+        ctx.two = nil
+
+        ctx.fail_and_return!('Something went wrong', :error_code => 401)
+        ctx.two = 2
+      end
+    end
+
+    it "returned context contains the error_code" do
+      result = FailAndReturnWithErrorCodeAction.execute
+
+      expect(result).to be_failure
+      expect(result.error_code).to eq 401
+      expect(result.two).to be_nil
+    end
+  end
 end

--- a/spec/acceptance/fail_spec.rb
+++ b/spec/acceptance/fail_spec.rb
@@ -1,24 +1,26 @@
 require 'spec_helper'
 
-RSpec.describe "fail! returns immediately from executed block" do
-  class FailAction
-    extend LightService::Action
-    promises :one, :two
+RSpec.describe "fail_and_return!" do
+  describe "returns immediately from executed block" do
+    class FailAndReturnAction
+      extend LightService::Action
+      promises :one, :two
 
-    executed do |ctx|
-      ctx.one = 1
-      # Have to set it in Context
-      ctx.two = nil
+      executed do |ctx|
+        ctx.one = 1
+        # Have to set it in Context
+        ctx.two = nil
 
-      ctx.fail_and_return!('Something went wrong')
-      ctx.two = 2
+        ctx.fail_and_return!('Something went wrong')
+        ctx.two = 2
+      end
     end
-  end
 
-  it "returns immediately from executed block" do
-    result = FailAction.execute
+    it "returns immediately from executed block" do
+      result = FailAndReturnAction.execute
 
-    expect(result).to be_failure
-    expect(result.two).to be_nil
+      expect(result).to be_failure
+      expect(result.two).to be_nil
+    end
   end
 end


### PR DESCRIPTION
This is to address #154 

- [x] Add failing spec for `context.fail_and_return!` taking in an `error_code`
- [x] Implement fix allowing `context.fail_and_return!` to accept `error_code`