### PR TITLE
Add add_to_context and add_aliases organizer methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 vendor/bundle
 bin
+.idea

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -64,6 +64,16 @@ module LightService
       def logger
         @logger
       end
+
+      def add_to_context(**args)
+        args.map do |key, value|
+          execute(->(ctx) { ctx[key.to_sym] = value })
+        end
+      end
+
+      def add_aliases(args)
+        execute(->(ctx) { ctx.assign_aliases(ctx.aliases.merge(args)) })
+      end
     end
 
     module Macros

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -90,4 +90,18 @@ describe LightService::Organizer do
       expect(reduced).to eq(ctx)
     end
   end
+
+  context "#add_to_context" do
+    it 'should add to the context' do
+      result = TestDoubles::AnOrganizerThatAddsToContext.call
+      expect(result[:strongest_avenger]).to eq :thor
+    end
+  end
+
+  context "#add_aliases" do
+    it 'should add to the aliases' do
+      result = TestDoubles::AnOrganizerThatAddsAliases.call
+      expect(result[:baz]).to eq :bar
+    end
+  end
 end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -555,4 +555,30 @@ module TestDoubles
       ctx.total += ctx.number
     end
   end
+
+  class AnOrganizerThatAddsToContext
+    extend LightService::Organizer
+    def self.call
+      with.reduce(actions)
+    end
+
+    def self.actions
+      [
+        add_to_context(:strongest_avenger => :thor)
+      ]
+    end
+  end
+
+  class AnOrganizerThatAddsAliases
+    extend LightService::Organizer
+    def self.call
+      with(:foo => :bar).reduce(actions)
+    end
+
+    def self.actions
+      [
+        add_aliases(:foo => :baz)
+      ]
+    end
+  end
 end


### PR DESCRIPTION
Hi @adomokos!

I'm creating this PR to potentially add two new utility methods upstream that I've found very useful in working with LightService.

The background on why I've found these useful is as follows:

1. It is common for organizers to share actions
2. I've found it quite useful to nest organizers when they perform common series of actions by adding `SomeOtherOrganizer.actions` to the list of actions in another Organizer
3. When pulling actions from another organizer directly, the module macro methods aren't executed and the actions pulled in will likely fail due to keys not in the context.

Therefore, these two simple methods allow an Organizer's actions to be effectively pulled in and executed within another Organizer.

So, instead of this pattern:
```
class OrganizerOne
  extend LightService::Organizer
  aliases(foo: :bar)
	
  def self.call
	with(...).reduce(actions
  end

  def self.actions
	[
	  ...
	]
  end
end
```

This pattern can be used instead:

```
class OrganizerOne
  extend LightService::Organizer

  def self.call
	with(...).reduce(actions)
  end

  def self.actions
	[
	  add_aliases(foo: :bar),
	  ...
	]
  end
```

And this allows another organizer to have the alias in its context like so:

```
class OrganizerTwo
  extend LightService::Organizer
  
  ...

  def self.actions
	[
	  OrganizerOne.actions # alias foo: :bar will now be in the context
	]
  end
```

# edit
since I forgot to mention add_to_context

The second method added, `add_to_context`, is simply DSL sugar that explicitly states that you're adding something to the context.

You can achieve this now by using an execute proc, but the `add_to_context` method makes it more explicit what you're doing.

So this:

`execute( ->(ctx) { add_to_context(foo: :bar, baz: :qux) }`

can now be executed directly as an action macro:

`add_to_context(foo: :bar, baz: :qux)`

Thanks again, look forward to hearing from you!