### PR TITLE
Make activesupport a runtime dependency

### DIFF
--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LightService::VERSION
 
-  gem.add_development_dependency("activesupport", ">= 5.2.2")
+  gem.add_runtime_dependency("activesupport", ">= 5.2.2")
+  
   gem.add_development_dependency("rspec", "~> 3.0")
   gem.add_development_dependency("simplecov", "~> 0.16.1")
   gem.add_development_dependency("rubocop", "~> 0.68.0")


### PR DESCRIPTION
It's used not just in tests, but during runtime as well

Related to https://github.com/adomokos/light-service/pull/157