### PR TITLE
Make activesupport a runtime dependency

### DIFF
--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LightService::VERSION
 
-  gem.add_development_dependency("activesupport", ">= 5.2.2")
+  gem.add_runtime_dependency("activesupport", ">= 3.0.0")
+
   gem.add_development_dependency("rspec", "~> 3.0")
   gem.add_development_dependency("simplecov", "~> 0.16.1")
   gem.add_development_dependency("rubocop", "~> 0.63.1")


### PR DESCRIPTION
We use it in tests but we also use it during runtime

Related to https://github.com/adomokos/light-service/pull/157