### PR TITLE
Add two asterisks, fixes the Ruby 2.7.0 warning

### DIFF
--- a/lib/light-service/localization_adapter.rb
+++ b/lib/light-service/localization_adapter.rb
@@ -34,7 +34,7 @@ module LightService
       scope = i18n_scope_from_class(action_class, type)
       options[:scope] = scope
 
-      I18n.t(key, options)
+      I18n.t(key, **options)
     end
 
     def i18n_scope_from_class(action_class, type)


### PR DESCRIPTION
No logic changes.