### PR TITLE
Add `organized_by` into context

### DIFF
--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -8,16 +8,17 @@ module LightService
 
   # rubocop:disable ClassLength
   class Context < Hash
-    attr_accessor :message, :error_code, :current_action
+    attr_accessor :message, :error_code, :current_action, :organized_by
 
     def initialize(context = {},
                    outcome = Outcomes::SUCCESS,
                    message = '',
                    error_code = nil)
-      @outcome = outcome
-      @message = message
-      @error_code = error_code
+      @outcome        = outcome
+      @message        = message
+      @error_code     = error_code
       @skip_remaining = false
+
       context.to_hash.each { |k, v| self[k] = v }
     end
 

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -14,9 +14,9 @@ module LightService
                    outcome = Outcomes::SUCCESS,
                    message = '',
                    error_code = nil)
-      @outcome        = outcome
-      @message        = message
-      @error_code     = error_code
+      @outcome = outcome
+      @message = message
+      @error_code = error_code
       @skip_remaining = false
 
       context.to_hash.each { |k, v| self[k] = v }

--- a/lib/light-service/organizer/with_reducer.rb
+++ b/lib/light-service/organizer/with_reducer.rb
@@ -1,10 +1,16 @@
 module LightService
   module Organizer
     class WithReducer
-      attr_reader :context
+      attr_reader   :context
+      attr_accessor :organizer
+
+      def initialize(monitored_organizer = nil)
+        @organizer = monitored_organizer
+      end
 
       def with(data = {})
         @context = LightService::Context.make(data)
+        @context.organized_by = organizer
         self
       end
 

--- a/lib/light-service/organizer/with_reducer_factory.rb
+++ b/lib/light-service/organizer/with_reducer_factory.rb
@@ -4,7 +4,7 @@ module LightService
       def self.make(monitored_organizer)
         logger = monitored_organizer.logger ||
                  LightService::Configuration.logger
-        decorated = WithReducer.new
+        decorated = WithReducer.new(monitored_organizer)
 
         return decorated if logger.nil?
 

--- a/lib/light-service/organizer/with_reducer_log_decorator.rb
+++ b/lib/light-service/organizer/with_reducer_log_decorator.rb
@@ -8,6 +8,9 @@ module LightService
       def initialize(organizer, decorated: WithReducer.new, logger:)
         @decorated = decorated
         @organizer = organizer
+
+        decorated.organizer = organizer
+
         @logger = logger
         @logged = false
       end

--- a/spec/acceptance/organizer/iterate_spec.rb
+++ b/spec/acceptance/organizer/iterate_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe LightService::Organizer do
   end
 
   it "knows that it's being iterated from within an organizer" do
-    result = TestDoubles::TestIterate.call(:number => 1, :counters => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call(:number => 1,
+                                           :counters => [1, 2, 3, 4])
 
     expect(result.organized_by).to eq TestDoubles::TestIterate
   end

--- a/spec/acceptance/organizer/iterate_spec.rb
+++ b/spec/acceptance/organizer/iterate_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe LightService::Organizer do
     expect(result.number).to eq(5)
   end
 
+  it "knows that it's being iterated from within an organizer" do
+    result = TestDoubles::TestIterate.call(:number => 1, :counters => [1, 2, 3, 4])
+
+    expect(result.organized_by).to eq TestDoubles::TestIterate
+  end
+
   it 'will not iterate over a failed context' do
     empty_context.fail!('Something bad happened')
 

--- a/spec/acceptance/organizer/reduce_if_spec.rb
+++ b/spec/acceptance/organizer/reduce_if_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe LightService::Organizer do
     expect(result).to be_success
   end
 
+  it "knows that it's being reduced from within an organizer" do
+    result = TestDoubles::TestIterate.call(:number => 1, :counters => [1, 2, 3, 4])
+
+    expect(result.organized_by).to eq TestDoubles::TestIterate
+  end
+
   it 'skips actions within in its own scope' do
     org = Class.new do
       extend LightService::Organizer

--- a/spec/acceptance/organizer/reduce_if_spec.rb
+++ b/spec/acceptance/organizer/reduce_if_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe LightService::Organizer do
     expect(result).to be_success
   end
 
-  it "knows that it's being reduced from within an organizer" do
+  it "knows that it's being conditionally reduced from within an organizer" do
     result = TestDoubles::TestIterate.call(:number => 1,
                                            :counters => [1, 2, 3, 4])
 

--- a/spec/acceptance/organizer/reduce_if_spec.rb
+++ b/spec/acceptance/organizer/reduce_if_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe LightService::Organizer do
   end
 
   it "knows that it's being reduced from within an organizer" do
-    result = TestDoubles::TestIterate.call(:number => 1, :counters => [1, 2, 3, 4])
+    result = TestDoubles::TestIterate.call(:number => 1,
+                                           :counters => [1, 2, 3, 4])
 
     expect(result.organized_by).to eq TestDoubles::TestIterate
   end

--- a/spec/acceptance/organizer/reduce_until_spec.rb
+++ b/spec/acceptance/organizer/reduce_until_spec.rb
@@ -40,4 +40,10 @@ RSpec.describe LightService::Organizer do
     result = TestReduceUntil.call(empty_context)
     expect(result).to be_success
   end
+
+  it "knows that it's being reduced from within an organizer" do
+    result = TestReduceUntil.call(:number => 1)
+
+    expect(result.organized_by).to eq TestReduceUntil
+  end
 end

--- a/spec/acceptance/organizer/reduce_until_spec.rb
+++ b/spec/acceptance/organizer/reduce_until_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe LightService::Organizer do
     expect(result).to be_success
   end
 
-  it "knows that it's being reduced from within an organizer" do
+  it "is expected to know its organizer when reducing until a condition" do
     result = TestReduceUntil.call(:number => 1)
 
     expect(result.organized_by).to eq TestReduceUntil

--- a/spec/action_spec.rb
+++ b/spec/action_spec.rb
@@ -68,6 +68,14 @@ describe LightService::Action do
     expect(result.to_hash).to eq(:number => 2)
   end
 
+  context "when called directly" do
+    it "is expected to not be organized" do
+      result = TestDoubles::AddsTwoActionWithFetch.execute(context)
+
+      expect(result.organized_by).to be_nil
+    end
+  end
+
   context "when invoked with hash" do
     it "creates LightService::Context implicitly" do
       ctx = { :some_key => "some value" }

--- a/spec/organizer_spec.rb
+++ b/spec/organizer_spec.rb
@@ -19,6 +19,11 @@ describe LightService::Organizer do
       result = TestDoubles::AnOrganizer.call(:user => user)
       expect(result).to eq(ctx)
     end
+
+    it "sets itself as the organizer" do
+      result = TestDoubles::AnOrganizer.call(:user => user)
+      expect(result.organized_by).to eq TestDoubles::AnOrganizer
+    end
   end
 
   context "when #with is called with Context" do


### PR DESCRIPTION
Hi there,

TL;DR - Context's now have an `#organized_by` attr.

We recently came across an issue where we were using actions directly, outside of an organizer. When they failed, and triggered a roll back (like when they're used with an organizer), they instead raise an `FailWithRollbackError` exception, which is used internally by LS for managing roll back flow.

This is fine, but there are times when we need to just call the action directly. Rather than duplicate the action, and make it fail without a rollback, I added the ability for a context to know if it's part of an organized run, or a single action.

We can then put an (admittedly ugly) if/else block and fail it differently depending on whether or not the action is called directly or from an organizer.

Hope you like, please let me know if there's anything I need to change.

e.g.

```ruby
class FooAction
  extend LightService::Action

  executed do |ctx|
    if ctx.organized_by.nil? # Running in an action, fail with no rollback
      ctx.fail!
    else # ctx.organized_by would == FooOrganizer, fail with rollback
      ctx.fail_with_rollback!
    end
  end
end
```