### PR TITLE
We are not supporting Active Support >= 3.0

### DIFF
--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LightService::VERSION
 
-  gem.add_runtime_dependency("activesupport", ">= 3.0.0")
+  gem.add_runtime_dependency("activesupport", ">= 4.0.0")
 
   gem.add_development_dependency("generator_spec", "~> 0.9.4")
   gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.


### PR DESCRIPTION
This version is not even tested as of [this PR](https://github.com/adomokos/light-service/pull/197).