### PR TITLE
🐛 Fix callback current action

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -44,6 +44,8 @@ module LightService
             catch(:jump_when_failed) do
               call_before_action(action_context)
               yield(action_context)
+
+              # Reset the stored action in case it was changed downstream
               action_context.current_action = self
               call_after_action(action_context)
             end

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -44,6 +44,7 @@ module LightService
             catch(:jump_when_failed) do
               call_before_action(action_context)
               yield(action_context)
+              action_context.current_action = self
               call_after_action(action_context)
             end
           end

--- a/spec/acceptance/after_actions_spec.rb
+++ b/spec/acceptance/after_actions_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe 'Action after_actions' do
     end
   end
 
+  context 'with callbacks' do
+    it 'ensures the correct :current_action is set' do
+      TestDoubles::TestWithCallback.after_actions = [
+        lambda do |ctx|
+          if ctx.current_action == TestDoubles::IterateCollectionAction
+            ctx.total -= 1000
+          end
+        end
+      ]
+
+      result = TestDoubles::TestWithCallback.call
+
+      expect(result.counter).to eq(3)
+      expect(result.total).to eq(-994)
+    end
+  end
+
   describe 'after_actions can be appended' do
     it 'adds to the :_after_actions collection' do
       TestDoubles::AdditionOrganizer.append_after_actions(


### PR DESCRIPTION
I came across a bug where the `current_action` is not changed back correctly after invoking callbacks. This has the consequence of any kind of after action callbacks not having the correct `current_action` set.

For the test that was added, if you add `puts ctx.current_action` to the `after_actions` hook, you'll get the following printout:
```
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::AddToTotalAction
```

You'll see the last action is printed twice. That's because the very last one should have `TestDoubles::IterateCollectionAction` as it's `:current_action` instead of a duplicate `TestDoubles::AddToTotalAction`. 

I took a stab at adding the test and where I think is the simplest place to make it pass. After the change to `action.rb`, the output from that same `puts` statement looks like:

```
TestDoubles::SetUpContextAction
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::IncrementCountAction
TestDoubles::AddToTotalAction
TestDoubles::IterateCollectionAction
```

This gets the desired effect for setting the current action, let me know if there is a better way to go about solving this! It's also my first time contributing to OS in a while, so any other feedback is welcome 🙏 

[Gitmoji Ref](https://gitmoji.dev/)