### PR TITLE
✨ Permit allowed attributes

### DIFF
--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -14,12 +14,20 @@ module LightService
     end
 
     module Macros
+      def allows(args)
+        allowed_keys.merge!(args)
+      end
+
       def expects(*args)
         expected_keys.concat(args)
       end
 
       def promises(*args)
         promised_keys.concat(args)
+      end
+
+      def allowed_keys
+        @allowed_keys ||= {}
       end
 
       def expected_keys
@@ -32,6 +40,9 @@ module LightService
 
       def executed
         define_singleton_method :execute do |context = {}|
+          allowed_keys.each do |key, default_value|
+            context[key] ||= default_value
+          end
           action_context = create_action_context(context)
           return action_context if action_context.stop_processing?
 
@@ -73,7 +84,7 @@ module LightService
       end
 
       def all_keys
-        expected_keys + promised_keys
+        expected_keys + promised_keys + allowed_keys.keys
       end
 
       def call_before_action(context)

--- a/spec/action_allowed_keys_spec.rb
+++ b/spec/action_allowed_keys_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'test_doubles'
+
+describe ":allows macro" do
+  context "when allowed keys are passed in" do
+    it "uses the passed value" do
+      resulting_context = TestDoubles::AddsArgumentOrTwo.execute(
+        counter: 10,
+        increment: 5
+      )
+      expect(resulting_context[:result]).to eq(15)
+    end
+  end
+
+  context "when allowed keys are not passed in" do
+    it "uses the default value" do
+      resulting_context = TestDoubles::AddsArgumentOrTwo.execute(
+        counter: 10
+      )
+      expect(resulting_context[:result]).to eq(12)
+    end
+  end
+end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -590,4 +590,15 @@ module TestDoubles
       [add_aliases(:foo => :baz)]
     end
   end
+
+  class AddsArgumentOrTwo
+    extend LightService::Action
+    allows increment: 2
+    expects :counter
+    promises :result
+
+    executed do |context|
+      context.result = context.counter + context.increment
+    end
+  end
 end


### PR DESCRIPTION
Allowed attributes can be defined in the action context for dependency
injection. If they aren't explictly passed, the default value is used.

This commit is mostly a proof or concept, more work is needed to add
documentation, more tests etc., but I'd like to receive your opinion about
it before eventually adding more work.

E.g.:

```ruby
  class AddsArgumentOrTwo
    extend LightService::Action
    allows increment: 2
    expects :counter
    promises :result

    executed do |context|
      context.result = context.counter + context.increment
    end
  end
```