### PR TITLE
Implement support for default values for optional expected keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,24 +551,28 @@ end
 The `expects` macro will pull the value with the expected key from the context, and
 makes it available to you through a reader.
 
-The `promises` macro will not only check if the context has the promised keys, it also sets it for you in the context if
-you use the accessor with the same name in the same way as the expects macro.
+The `promises` macro will not only check if the context has the promised keys, it
+also sets them for you in the context if you use the accessor with the same name,
+much the same way as the expects macro works.
 
-The context object is essentially a smarter than normal Hash. Take a look at [this spec](spec/action_expects_and_promises_spec.rb)
+The context object is essentially a smarter-than-normal Hash. Take a look at [this spec](spec/action_expects_and_promises_spec.rb)
 to see expects and promises used with and without accessors.
 
 ### Default values for optional Expected keys
 
-When you have an expected key, but it has a sensible default that should be used everywhere and
-overridden on an as-needed basis, you can specify a default value. An example use-case is a flag
-that will allow a failure from a service under most circumstances.
+When you have an expected key that has a sensible default which should be used everywhere and
+only overridden on an as-needed basis, you can specify a default value. An example use-case
+is a flag that allows a failure from a service under most circumstances to avoid failing an
+entire workflow because of a non-critical action.
 
 LightService provides two mechanisms for specifying default values:
 
 1. A static value that is used as-is
 2. A callable that takes the current context as a param
 
-Using the above use case, consider an action that sends a text message:
+Using the above use case, consider an action that sends a text message. In most cases,
+if there is a problem sending the text message, it might be OK for it to fail. We will
+`expect` an `allow_failure` key, but set it with a default, like so:
 
 ```ruby
 class SendSMS

--- a/README.md
+++ b/README.md
@@ -530,7 +530,8 @@ These ideas are originally from Aspect Oriented Programming, read more about the
 ## Expects and Promises
 The `expects` and `promises` macros are rules for the inputs/outputs of an action.
 `expects` describes what keys it needs to execute, and `promises` makes sure the keys are in the context after the
-action is reduced. If either of them are violated, a custom exception is thrown.
+action is reduced. If either of them are violated, a `LightService::ExpectedKeysNotInContextError` or
+`LightService::PromisedKeysNotInContextError` exception respectively will be thrown.
 
 This is how it's used:
 ```ruby

--- a/README.md
+++ b/README.md
@@ -577,9 +577,12 @@ class SendSMS
   expects :allow_failure, default: true
 
   executed do |context|
-    sms_status = SMSService.send(ctx.user.mobile_number, ctx.message)
+    sms_api = SMSService.new(key: ENV["SMS_API_KEY"])
+    status  = sms_api.send(ctx.user.mobile_number, ctx.message)
 
-    ctx.fail!(sms_status.message) unless ctx.allow_failure
+    if !status.sent_ok?
+      ctx.fail!(status.err_msg) unless ctx.allow_failure
+    end
   end
 end
 ```
@@ -594,9 +597,12 @@ class SendSMS
   expects :allow_failure, default: ->(ctx) { !ctx[:user].admin? } # Admins must always get SMS'
 
   executed do |context|
-    sms_status = SMSService.send(ctx.user.mobile_number, ctx.message)
+    sms_api = SMSService.new(key: ENV["SMS_API_KEY"])
+    status  = sms_api.send(ctx.user.mobile_number, ctx.message)
 
-    ctx.fail!(sms_status.message) unless ctx.allow_failure
+    if !status.sent_ok?
+      ctx.fail!(status.err_msg) unless ctx.allow_failure
+    end
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -534,39 +534,6 @@ action is reduced. If either of them are violated, a `LightService::ExpectedKeys
 `LightService::PromisedKeysNotInContextError` exception respectively will be thrown.
 
 This is how it's used:
-```ruby
-class FooAction
-  extend LightService::Action
-  expects :baz
-  promises :bar
-
-  executed do |context|
-    baz = context.fetch :baz
-
-    bar = baz + 2
-    context[:bar] = bar
-  end
-end
-```
-
-The `expects` macro does a bit more for you: it pulls the value with the expected key from the context, and
-makes it available to you through a reader. You can refactor the action like this:
-
-```ruby
-class FooAction
-  extend LightService::Action
-  expects :baz
-  promises :bar
-
-  executed do |context|
-    bar = context.baz + 2
-    context[:bar] = bar
-  end
-end
-```
-
-The `promises` macro will not only check if the context has the promised keys, it also sets it for you in the context if
-you use the accessor with the same name. The code above can be further simplified:
 
 ```ruby
 class FooAction
@@ -580,7 +547,14 @@ class FooAction
 end
 ```
 
-Take a look at [this spec](spec/action_expects_and_promises_spec.rb) to see the refactoring in action.
+The `expects` macro will pull the value with the expected key from the context, and
+makes it available to you through a reader.
+
+The `promises` macro will not only check if the context has the promised keys, it also sets it for you in the context if
+you use the accessor with the same name in the same way as the expects macro.
+
+The context object is essentially a smarter than normal Hash. Take a look at [this spec](spec/action_expects_and_promises_spec.rb)
+to see expects and promises used with and without accessors.
 
 ## Key Aliases
 The `aliases` macro sets up pairs of keys and aliases in an organizer. Actions can access the context using the aliases.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ LightService is a powerful and flexible service skeleton framework with an empha
     * [Skipping the Rest of the Actions](#skipping-the-rest-of-the-actions)
 * [Benchmarking Actions with Around Advice](#benchmarking-actions-with-around-advice)
 * [Before and After Action Hooks](#before-and-after-action-hooks)
+* [Expects and Promises](#expects-and-promises)
 * [Key Aliases](#key-aliases)
 * [Logging](#logging)
 * [Error Codes](#error-codes)

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -92,12 +92,8 @@ module LightService
         return false unless key.size == 2 && key.last.is_a?(Hash)
         return true if key.last.key?(:default)
 
-        err_msg = <<~ERR_MSG
-          Default values must be specified with a `default key`.
-          Expected: expects :#{key.first}, default: some_value
-          Got:      expects :#{key.first}, #{key.last.keys.first}: some_value
-        ERR_MSG
-
+        bad_key = key.last.keys.first
+        err_msg = "Specify defaults with a `default` key. You have #{bad_key}."
         raise UnusableExpectKeyDefaultError, err_msg
       end
 

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -15,6 +15,13 @@ module LightService
 
     module Macros
       def expects(*args)
+        if expect_key_having_default?(args)
+          available_defaults[args.first] = args.last[:default] \
+            if args.last.key?(:default)
+
+          args = [args.first]
+        end
+
         expected_keys.concat(args)
       end
 
@@ -28,6 +35,14 @@ module LightService
 
       def promised_keys
         @promised_keys ||= []
+      end
+
+      def available_defaults
+        @available_defaults ||= {}
+      end
+
+      def expect_key_having_default?(key)
+        key.size == 2 && key.last.is_a?(Hash)
       end
 
       def executed

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -82,8 +82,6 @@ module LightService
       private
 
       def create_action_context(context)
-        return context if context.is_a? LightService::Context
-
         usable_defaults(context).each do |ctx_key, default|
           context[ctx_key] = extract_default(default, context)
         end

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -16,8 +16,7 @@ module LightService
     module Macros
       def expects(*args)
         if expect_key_having_default?(args)
-          available_defaults[args.first] = args.last[:default] \
-            if args.last.key?(:default)
+          available_defaults[args.first] = args.last[:default]
 
           args = [args.first]
         end
@@ -90,7 +89,16 @@ module LightService
       end
 
       def expect_key_having_default?(key)
-        key.size == 2 && key.last.is_a?(Hash)
+        return false unless key.size == 2 && key.last.is_a?(Hash)
+        return true if key.last.key?(:default)
+
+        err_msg = <<~ERR_MSG
+          Default values must be specified with a `default key`.
+          Expected: expects :#{key.first}, default: some_value
+          Got:      expects :#{key.first}, #{key.last.keys.first}: some_value
+        ERR_MSG
+
+        raise UnusableExpectKeyDefaultError, err_msg
       end
 
       def create_action_context(context)

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -37,14 +37,6 @@ module LightService
         @promised_keys ||= []
       end
 
-      def available_defaults
-        @available_defaults ||= {}
-      end
-
-      def expect_key_having_default?(key)
-        key.size == 2 && key.last.is_a?(Hash)
-      end
-
       def executed(*_args, &block)
         define_singleton_method :execute do |context = Context.make|
           action_context = create_action_context(context)
@@ -91,6 +83,14 @@ module LightService
         else
           yield(context)
         end
+      end
+
+      def available_defaults
+        @available_defaults ||= {}
+      end
+
+      def expect_key_having_default?(key)
+        key.size == 2 && key.last.is_a?(Hash)
       end
 
       def create_action_context(context)

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -104,9 +104,7 @@ module LightService
       end
 
       def extract_default(default, context)
-        is_callable = default.respond_to?(:call)
-
-        return default unless is_callable
+        return default unless default.respond_to?(:call)
 
         default.call(context)
       end

--- a/lib/light-service/errors.rb
+++ b/lib/light-service/errors.rb
@@ -3,4 +3,5 @@ module LightService
   class ExpectedKeysNotInContextError < StandardError; end
   class PromisedKeysNotInContextError < StandardError; end
   class ReservedKeysInContextError < StandardError; end
+  class UnusableExpectKeyDefaultError < StandardError; end
 end

--- a/spec/action_optional_expected_keys_spec.rb
+++ b/spec/action_optional_expected_keys_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'test_doubles'
+
+describe ":expects macro using defaults" do
+  context "when all expected keys are supplied" do
+    it "is expected to ignore default values" do
+      outcome = TestDoubles::AddsNumbersWithOptionalDefaults.execute(
+        :first_number => 3,
+        :second_number => 5,
+        :third_number => 7
+      )
+
+      expect(outcome.total).to eq 15
+    end
+  end
+
+  context "when defaults are supplied" do
+    it "is expected to use static values" do
+      outcome = TestDoubles::AddsNumbersWithOptionalDefaults.execute(
+        :first_number => 3,
+        :second_number => 7
+      )
+
+      expect(outcome.total).to eq 20
+    end
+
+    it "is expected to use dynamic values" do
+      outcome = TestDoubles::AddsNumbersWithOptionalDefaults.execute(
+        :first_number => 3,
+        :third_number => 5
+      )
+
+      expect(outcome.total).to eq 18
+    end
+
+    it "is expected to process defaults in their defined order" do
+      outcome = TestDoubles::AddsNumbersWithOptionalDefaults.execute(
+        :third_number => 5,
+        :first_number => 3
+      )
+
+      expect(outcome.total).to eq 18
+    end
+
+    it "is expected to use all defaults if required" do
+      outcome = TestDoubles::AddsNumbersWithOptionalDefaults.execute(
+        :first_number => 3
+      )
+
+      expect(outcome.total).to eq 23
+    end
+  end
+end

--- a/spec/action_optional_expected_keys_spec.rb
+++ b/spec/action_optional_expected_keys_spec.rb
@@ -61,8 +61,22 @@ describe ":expects macro using defaults" do
 
   context "when defaults are misconfigured" do
     it "is expected to raise an exception" do
-      expect { TestDoubles::AddsNumbersWithIncorrectDefaults.execute }.to \
-        raise_error(LightService::UnusableExpectKeyDefaultError)
+      expect do
+        # Needs to be specified in the block
+        # as error is raised at define time
+        class AddsNumbersWithIncorrectDefaults
+          extend LightService::Action
+
+          expects  :first,  :default => 10 # This one is fine. Other two arent
+          expects  :second, :defalut => ->(ctx) { ctx[:first] + 7 }
+          expects  :third,  :deafult => 10
+          promises :total
+
+          executed do |ctx|
+            ctx.total = ctx.first + ctx.second + ctx.third
+          end
+        end
+      end.to raise_error(LightService::UnusableExpectKeyDefaultError)
     end
   end
 end

--- a/spec/action_optional_expected_keys_spec.rb
+++ b/spec/action_optional_expected_keys_spec.rb
@@ -55,7 +55,7 @@ describe ":expects macro using defaults" do
     it "is expected to process required defaults" do
       outcome = TestDoubles::OrganizerWithActionsUsingDefaults.call
 
-      expect(outcome.total).to eq 1000
+      expect(outcome.total).to eq 20
     end
   end
 end

--- a/spec/action_optional_expected_keys_spec.rb
+++ b/spec/action_optional_expected_keys_spec.rb
@@ -58,4 +58,11 @@ describe ":expects macro using defaults" do
       expect(outcome.total).to eq 20
     end
   end
+
+  context "when defaults are misconfigured" do
+    it "is expected to raise an exception" do
+      expect { TestDoubles::AddsNumbersWithIncorrectDefaults.execute }.to \
+        raise_error(LightService::UnusableExpectKeyDefaultError)
+    end
+  end
 end

--- a/spec/action_optional_expected_keys_spec.rb
+++ b/spec/action_optional_expected_keys_spec.rb
@@ -50,4 +50,12 @@ describe ":expects macro using defaults" do
       expect(outcome.total).to eq 23
     end
   end
+
+  context "when used within an organizer" do
+    it "is expected to process required defaults" do
+      outcome = TestDoubles::OrganizerWithActionsUsingDefaults.call
+
+      expect(outcome.total).to eq 1000
+    end
+  end
 end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -566,6 +566,19 @@ module TestDoubles
     end
   end
 
+  class AddsNumbersWithOptionalDefaults
+    extend LightService::Action
+
+    expects  :first_number
+    expects  :second_number, :default => ->(ctx) { ctx[:first_number] + 7 }
+    expects  :third_number,  :default => 10
+    promises :total
+
+    executed do |ctx|
+      ctx.total = ctx.first_number + ctx.second_number + ctx.third_number
+    end
+  end
+
   class AnOrganizerThatAddsToContext
     extend LightService::Organizer
     def self.call

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -589,6 +589,18 @@ module TestDoubles
     end
   end
 
+  class AddsNumbersWithIncorrectDefaults
+    extend LightService::Action
+
+    expects  :first_number,  :defalut => ->(ctx) { ctx[:first_number] + 7 }
+    expects  :second_number, :deafult => 10
+    promises :total
+
+    executed do |ctx|
+      ctx.total = ctx.first_number + ctx.second_number
+    end
+  end
+
   class OrganizerWithActionsUsingDefaults
     extend LightService::Organizer
     def self.call

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -589,18 +589,6 @@ module TestDoubles
     end
   end
 
-  class AddsNumbersWithIncorrectDefaults
-    extend LightService::Action
-
-    expects  :first_number,  :defalut => ->(ctx) { ctx[:first_number] + 7 }
-    expects  :second_number, :deafult => 10
-    promises :total
-
-    executed do |ctx|
-      ctx.total = ctx.first_number + ctx.second_number
-    end
-  end
-
   class OrganizerWithActionsUsingDefaults
     extend LightService::Organizer
     def self.call

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -579,6 +579,20 @@ module TestDoubles
     end
   end
 
+  class OrganizerWithActionsUsingDefaults
+    extend LightService::Organizer
+    def self.call
+      with(:first_number => 1, :number => 1).reduce(actions)
+    end
+
+    def self.actions
+      [
+        AddsNumbersWithOptionalDefaults,
+        AddToTotalAction
+      ]
+    end
+  end
+
   class AnOrganizerThatAddsToContext
     extend LightService::Organizer
     def self.call


### PR DESCRIPTION
This PR extends the `expects` macro so that a default value can be supplied. When an expected key's value is not supplied, and there is a default, it will be used instead, and a `LightService::ExpectedKeysNotInContextError` will be avoided.

I've implemented support for both static default values and dynamic defaults. Dynamic defaults accept a callable that takes the context as a param.

Full documentation on how to use this feature is included. Tests are also included.

This should also resolve #215. It does also obsolete https://github.com/adomokos/light-service/pull/216 unfortunately.

Hope you like it :)