### PR TITLE
Support for named argument in ruby 3

### DIFF
--- a/lib/light-service/testing/context_factory.rb
+++ b/lib/light-service/testing/context_factory.rb
@@ -34,6 +34,8 @@ module LightService
       end
       # rubocop:enable Style/ArgumentsForwarding
 
+      ruby2_keywords :with if RUBY_VERSION >= "2.7"
+
       def initialize(organizer)
         @organizer = organizer
       end

--- a/spec/test_doubles.rb
+++ b/spec/test_doubles.rb
@@ -118,6 +118,15 @@ module TestDoubles
     end
   end
 
+  class NamedArgumentOrganiser
+    extend LightService::Organizer
+
+    def self.call(number:)
+      with(number: number) # rubocop:disable Style/HashSyntax
+        .reduce([AddsTwoAction])
+    end
+  end
+
   class NotExplicitlyReturningContextOrganizer
     extend LightService::Organizer
 

--- a/spec/testing/context_factory_spec.rb
+++ b/spec/testing/context_factory_spec.rb
@@ -60,3 +60,18 @@ describe 'ContextFactory - used with AdditionOrganizer' do
     end
   end
 end
+
+describe 'ContextFactory - used with NamedArgumentOrganiser' do
+  let(:organizer) { TestDoubles::NamedArgumentOrganiser }
+
+  # it's relevant to test this as handling of named arguments changed between ruby 2.7 and 3.0
+  it 'pass named arguments to the organiser' do
+    ctx =
+      LightService::Testing::ContextFactory
+      .make_from(organizer)
+      .for(TestDoubles::AddsTwoAction)
+      .with(number: 2) # rubocop:disable Style/HashSyntax
+
+    expect(ctx[:number]).to eq(2)
+  end
+end


### PR DESCRIPTION
I've tried to update one of our project to ruby 3.0 and the only issue was in our services spec using ContextFactory.

We use named argument a lot and 3.0 break this when they're not passed explicitly using the double splat operator. `ruby2_keywords` marks the method as using the old style of named arguments. Calling it this way should works with older 2.x versions as well.