### PR TITLE
Relax activesupport dependency

### DIFF
--- a/lib/generators/light_service/generator_utils.rb
+++ b/lib/generators/light_service/generator_utils.rb
@@ -26,6 +26,10 @@ module LightService
       end
 
       def create_required_gen_vals_from(name)
+        # Not using dry-inflector here, because generators are used only
+        # within Rails project thus we can relay on ActiveSupport presence.
+        # Maybe plan to split LightService::Generators into a separate
+        # gem (e.g.: light_service-rails-generators)
         path_parts = name.underscore.split('/')
 
         {

--- a/lib/light-service.rb
+++ b/lib/light-service.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'active_support/core_ext/string'
+require 'i18n'
 
 require 'light-service/version'
 

--- a/lib/light-service.rb
+++ b/lib/light-service.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'i18n'
+require 'structured_warnings'
 
 require 'light-service/version'
 

--- a/lib/light-service/action.rb
+++ b/lib/light-service/action.rb
@@ -1,4 +1,4 @@
-require 'active_support/deprecation'
+require 'structured_warnings'
 
 module LightService
   module Action
@@ -9,7 +9,7 @@ module LightService
     def self.included(base_class)
       msg = "including LightService::Action is deprecated. " \
             "Please use `extend LightService::Action` instead"
-      ActiveSupport::Deprecation.warn(msg)
+      warn(StructuredWarnings::DeprecatedMethodWarning, msg)
       base_class.extend Macros
     end
 

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -1,4 +1,4 @@
-require 'active_support/deprecation'
+require 'structured_warnings'
 
 module LightService
   module Outcomes
@@ -61,7 +61,7 @@ module LightService
     def outcome
       msg = '`Context#outcome` attribute reader is ' \
             'DEPRECATED and will be removed'
-      ActiveSupport::Deprecation.warn(msg)
+      warn(StructuredWarnings::DeprecatedMethodWarning, msg)
       @outcome
     end
 
@@ -103,7 +103,7 @@ module LightService
     def skip_all!(message = nil)
       warning_msg = "Using skip_all! has been deprecated, " \
                     "please use `skip_remaining!` instead."
-      ActiveSupport::Deprecation.warn(warning_msg)
+      warn(StructuredWarnings::DeprecatedMethodWarning, warning_msg)
 
       skip_remaining!(message)
     end

--- a/lib/light-service/localization_adapter.rb
+++ b/lib/light-service/localization_adapter.rb
@@ -1,5 +1,13 @@
+require "dry/inflector"
+
 module LightService
   class LocalizationAdapter
+    attr_reader :inflector
+
+    def initialize
+      @inflector = Dry::Inflector.new
+    end
+
     def failure(message_or_key, action_class, i18n_options = {})
       find_translated_message(message_or_key,
                               action_class,
@@ -38,7 +46,7 @@ module LightService
     end
 
     def i18n_scope_from_class(action_class, type)
-      "#{action_class.name.underscore}.light_service.#{type.to_s.pluralize}"
+      "#{inflector.underscore(action_class.name)}.light_service.#{inflector.pluralize(type.to_s)}"
     end
   end
 end

--- a/lib/light-service/orchestrator.rb
+++ b/lib/light-service/orchestrator.rb
@@ -116,7 +116,7 @@ module LightService
       def issue_deprecation_warning_for(method_name)
         msg = "`Orchestrator##{method_name}` is DEPRECATED and will be " \
               "removed, please switch to `Organizer##{method_name} instead. "
-        ActiveSupport::Deprecation.warn(msg)
+        warn(StructuredWarnings::DeprecatedMethodWarning, msg)
       end
     end
   end

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -1,4 +1,4 @@
-require 'active_support/deprecation'
+require 'structured_warnings'
 
 module LightService
   module Organizer
@@ -10,7 +10,7 @@ module LightService
     def self.included(base_class)
       warning_msg = "including LightService::Organizer is deprecated. " \
                     "Please use `extend LightService::Organizer` instead"
-      ActiveSupport::Deprecation.warn(warning_msg)
+      warn(StructuredWarnings::DeprecatedMethodWarning, warning_msg)
       extended(base_class)
     end
 

--- a/lib/light-service/organizer/verify_call_method_exists.rb
+++ b/lib/light-service/organizer/verify_call_method_exists.rb
@@ -15,7 +15,7 @@ module LightService
                       "its entry method (the one that calls with & reduce) " \
                       "should be named `call`. " \
                       "Please use #{klass}.call going forward."
-        ActiveSupport::Deprecation.warn(warning_msg)
+        warn(StructuredWarnings::DeprecatedMethodWarning, warning_msg)
       end
 
       def self.caller_method(first_caller)

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.6.0'
 
   gem.add_runtime_dependency("activesupport", ">= 4.0.0")
+  gem.add_runtime_dependency("i18n")
+  gem.add_runtime_dependency("dry-inflector")
 
   gem.add_development_dependency("generator_spec", "~> 0.9.4")
   gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency("activesupport", ">= 4.0.0")
   gem.add_runtime_dependency("i18n")
   gem.add_runtime_dependency("dry-inflector")
+  gem.add_runtime_dependency("structured_warnings")
 
   gem.add_development_dependency("generator_spec", "~> 0.9.4")
   gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.

--- a/spec/acceptance/include_warning_spec.rb
+++ b/spec/acceptance/include_warning_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
+require 'structured_warnings_helper'
 
 describe "Including is discouraged" do
   context "when including LightService::Organizer" do
     it "gives warning" do
       expected_msg = "including LightService::Organizer is deprecated. " \
                      "Please use `extend LightService::Organizer` instead"
-      expect(ActiveSupport::Deprecation).to receive(:warn)
-        .with(expected_msg)
 
-      class OrganizerIncludingLS
-        include LightService::Organizer
-      end
+      expect do
+        class OrganizerIncludingLS
+          include LightService::Organizer
+        end
+      end.to warn_with(StructuredWarnings::DeprecatedMethodWarning, expected_msg)
     end
   end
 
@@ -18,12 +19,12 @@ describe "Including is discouraged" do
     it "gives warning" do
       expected_msg = "including LightService::Action is deprecated. " \
                      "Please use `extend LightService::Action` instead"
-      expect(ActiveSupport::Deprecation).to receive(:warn)
-        .with(expected_msg)
 
-      class ActionIncludingLS
-        include LightService::Action
-      end
+      expect do
+        class ActionIncludingLS
+          include LightService::Action
+        end
+      end.to warn_with(StructuredWarnings::DeprecatedMethodWarning, expected_msg)
     end
   end
 end

--- a/spec/acceptance/not_having_call_method_warning_spec.rb
+++ b/spec/acceptance/not_having_call_method_warning_spec.rb
@@ -4,10 +4,6 @@ require 'test_doubles'
 describe "Organizer should invoke with/reduce from a call method" do
   context "when the organizer does not have a `call` method" do
     it "gives warning" do
-      expect(ActiveSupport::Deprecation)
-        .to receive(:warn)
-        .with(/^The <OrganizerWithoutCallMethod> class is an organizer/)
-
       class OrganizerWithoutCallMethod
         extend LightService::Organizer
 
@@ -15,16 +11,15 @@ describe "Organizer should invoke with/reduce from a call method" do
           reduce([])
         end
       end
-
-      OrganizerWithoutCallMethod.do_something
+      expect { OrganizerWithoutCallMethod.do_something }.to warn_with(
+        StructuredWarnings::DeprecatedMethodWarning,
+        /^The <OrganizerWithoutCallMethod> class is an organizer/
+      )
     end
   end
 
   context "when the organizer has the `call` method" do
     it "does not issue a warning" do
-      expect(ActiveSupport::Deprecation)
-        .not_to receive(:warn)
-
       class OrganizerWithCallMethod
         extend LightService::Organizer
 
@@ -33,7 +28,9 @@ describe "Organizer should invoke with/reduce from a call method" do
         end
       end
 
-      OrganizerWithCallMethod.call
+      expect { OrganizerWithCallMethod.call }.not_to warn_with(
+        StructuredWarnings::DeprecatedMethodWarning
+      )
     end
   end
 end

--- a/spec/acceptance/skip_all_warning_spec.rb
+++ b/spec/acceptance/skip_all_warning_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe "skip_all! has been deprecated" do
 
     expected_msg = "Using skip_all! has been deprecated, " \
                    "please use `skip_remaining!` instead."
-    expect(ActiveSupport::Deprecation).to receive(:warn)
-      .with(expected_msg)
 
-    SkipAllDeprecatedAction.execute
+    expect { SkipAllDeprecatedAction.execute }
+      .to warn_with(StructuredWarnings::DeprecatedMethodWarning, expected_msg)
   end
 end

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'structured_warnings_helper'
 require 'test_doubles'
 
 RSpec.describe LightService::Context do
@@ -152,9 +153,15 @@ RSpec.describe LightService::Context do
   end
 
   it "warns about the outcome attribute reader being deprecated" do
-    expect(ActiveSupport::Deprecation).to receive(:warn)
+    expected_msg = '`Context#outcome` attribute reader is ' \
+                   'DEPRECATED and will be removed'
 
-    expect(context.outcome).to eq(::LightService::Outcomes::SUCCESS)
+    expect { context.outcome }.to warn_with(StructuredWarnings::DeprecatedMethodWarning, expected_msg)
+
+    # Since the warning is already tested, do not pollute rspec output here
+    StructuredWarnings::DeprecatedMethodWarning.disable do
+      expect(context.outcome).to eq(::LightService::Outcomes::SUCCESS)
+    end
   end
 
   it "can contain false values" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,5 +23,6 @@ require 'test_doubles'
 require 'stringio'
 require 'fileutils'
 require 'generator_spec'
+require 'structured_warnings_helper'
 
 I18n.enforce_available_locales = true

--- a/spec/structured_warnings_helper.rb
+++ b/spec/structured_warnings_helper.rb
@@ -1,0 +1,60 @@
+require 'structured_warnings/test'
+
+module StructuredWarningHelper
+  module_function
+
+  def parse_arguments(args) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    args = args.clone
+    first = args.shift
+
+    if first.is_a?(Class) && first <= StructuredWarnings::Base
+      warning = first
+      message = args.shift
+
+    elsif first.is_a?(Class) && !(first <= StructuredWarnings::Base)
+      raise ArgumentError, 'Warning issued with a class not inheriting from StructuredWarnings::Base'
+
+    elsif first.is_a? StructuredWarnings::Base
+      warning = first.class
+      message = first.message
+
+    elsif first.is_a? String
+      warning = StructuredWarnings::StandardWarning
+      message = first
+
+    else
+      warning = StructuredWarnings::Base
+      message = nil
+    end
+
+    unless args.empty?
+      raise ArgumentError,
+            "wrong number of arguments (#{args.size + 2} for 2)"
+    end
+
+    return warning, message
+  end
+
+  def args_inspect(args)
+    args.map(&:inspect).join(', ')
+  end
+end
+
+RSpec::Matchers.define :warn_with do |*args|
+  supports_block_expectations
+  warning, message = StructuredWarningHelper.parse_arguments(args)
+
+  match do |block|
+    w = StructuredWarnings::Test::Warner.new
+    StructuredWarnings.with_warner(w, &block)
+    expect(w.warned?(warning, message)).to be true
+  end
+
+  failure_message do |_block|
+    "<#{StructuredWarningHelper.args_inspect(args)}> has not been emitted."
+  end
+
+  failure_message_when_negated do |_block|
+    "<#{StructuredWarningHelper.args_inspect(args)}> has been emitted but it was not expected."
+  end
+end

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -1,9 +1,5 @@
 RSpec.shared_context 'expect orchestrator warning' do
-  before do
-    expect(ActiveSupport::Deprecation)
-      .to receive(:warn)
-      .with(/^`Orchestrator#/)
-      .at_least(:once)
+  around(:example) do |example|
+    expect { example.run }.to warn_with StructuredWarnings::DeprecatedMethodWarning
   end
 end
-


### PR DESCRIPTION
Given #226 and the bleeding announced in https://github.com/adomokos/light-service/issues/153#issuecomment-528679739 the goal of this PR is to relax the dependency this gem has on ActiveSupport.

**Why not removing it completely?**

It turns that the only part of the gem which continues to require ActiveSupport are the Rails generators. They were introduced recently in https://github.com/adomokos/light-service/pull/194. Thus I cannot afford to remove ActiveSupport with a one-shot PR. Nor I want to take decisions about how to continue from now on w/o including maintainer and community into the discussion.

**Is it worth to add more dependencies w/o removing ActiveSupport?**

Ideally not, but from a transitional perspective, yes. Now we have a single well scoped feature requiring ActiveSupport instead of having code bites spread all over the code base.
I'm bringing the gem in a more free and easier to manage position in regard of AS dep.

**What about the two new dependencies?**

I added https://dry-rb.org/gems/dry-inflector/ and https://github.com/schmidt/structured_warnings

Both were choosen because they are small, dependency-free gems with single functionality.

`dry-inflector` is from the (beloved by me) dry-rb ecosystem (https://dry-rb.org/). Neat, iper-atomic and well written. It is the Hanami inflector.

`structured_warnings` is a neat, very small gem; it has not been updated recently, but IMO it doesn't need to be. It works on  ruby 3.1 and its approach is simple and far (FAR) less polluting than ActiveSupport's one. I was able to implement a custom matcher for `rspec` too, writing expressive tests. Moreover its interface made possible to do a surgical substitution in the actual code base.

___

From my point of view, being the maintainer of the project, I'd think about splitting rails generators into a separate gem. This would enclose ActiveSupport and Rails-only things in cleaner context, easier to maintain. And the test suite of the "core" gem would lose all the complexity inherent to testing against all the possible AS versions.

I thought to open this one as a draft, but I decided to concretely propose something :) No problem turning it into draft or to use this just as a discussion desk and then close it.

Thanks for your attention. 