### PR TITLE
CI: Add Ruby 3.3 to matrix

### DIFF
--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -13,10 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: [2.7, '3.0', '3.1', '3.2']
+        ruby: [2.7, '3.0', '3.1', '3.2', '3.3']
         gemfile: [activesupport_5, activesupport_6, activesupport_7]
         exclude:
           - ruby: '3.2'
+            gemfile: activesupport_5
+          - ruby: '3.3'
             gemfile: activesupport_5
           - ruby: 2.7
             gemfile: activesupport_7


### PR DESCRIPTION
This PR adds the current stable Ruby version to the build matrix.