### PR TITLE
Re-enable simplecov and codecov coverage analysis

### DIFF
--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -2,27 +2,45 @@ name: CI Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu-latest, macos-latest]
         ruby: ['3.1', '3.2', '3.3']
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     env:
       RUN_COVERAGE_REPORT: true
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rspec spec
-      - run: bundle exec rubocop
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run tests and Rubocop
+        run: |
+          bundle exec rspec spec
+          bundle exec rubocop
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage.xml
+          flags: unittests
+          verbose: true
+

--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -15,6 +15,9 @@ jobs:
         os: [ubuntu, macos]
         ruby: ['3.1', '3.2', '3.3']
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    env:
+      RUN_COVERAGE_REPORT: true
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://img.shields.io/gem/v/light-service.svg)](https://rubygems.org/gems/light-service)
 [![CI Tests](https://github.com/adomokos/light-service/actions/workflows/project-build.yml/badge.svg)](https://github.com/adomokos/light-service/actions/workflows/project-build.yml)
-[![Codecov](https://codecov.io/gh/adomokos/light-service/branch/master/graph/badge.svg)](https://codecov.io/gh/adomokos/light-service)
+[![Codecov](https://codecov.io/gh/adomokos/light-service/branch/main/graph/badge.svg)](https://codecov.io/gh/adomokos/light-service)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](http://opensource.org/licenses/MIT)
 [![Download Count](https://img.shields.io/badge/download%3A-~5%20million-blue)](https://rubygems.org/gems/light-service)
 [![Code Climate](https://codeclimate.com/github/adomokos/light-service.svg)](https://codeclimate.com/github/adomokos/light-service)

--- a/lib/light-service/deprecation_warning.rb
+++ b/lib/light-service/deprecation_warning.rb
@@ -1,6 +1,7 @@
 module LightService
   module Deprecation
     class << self
+      # :nocov:
       # Basic implementation of a deprecation warning
       def warn(message, callstack = caller)
         # Construct the warning message
@@ -12,6 +13,7 @@ module LightService
 
         # Additional logging or actions can be added here
       end
+      # :nocov:
     end
   end
 end

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.
   gem.add_development_dependency("rspec", "~> 3.0")
   gem.add_development_dependency("simplecov", "~> 0.17")
-  gem.add_development_dependency("codecov", "~> 0.1")
+  gem.add_development_dependency("simplecov-cobertura", "~> 2.1")
   gem.add_development_dependency("rubocop", "~> 1.26.0")
   gem.add_development_dependency("rubocop-performance", "~> 1.2.0")
   gem.add_development_dependency("pry", "~> 0.14")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,10 @@ if ENV['RUN_COVERAGE_REPORT']
   end
   SimpleCov.minimum_coverage_by_file 90
 
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+  # require 'codecov'
+  # SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
 require 'light-service'


### PR DESCRIPTION
This got lost when I moved the CI from Travis to GitHub action. Let's use it again!