### PR TITLE
CI: trust bundler: cache

### DIFF
--- a/.github/workflows/project-build.yml
+++ b/.github/workflows/project-build.yml
@@ -26,10 +26,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true # 'bundle install' and cache gems
 
       - name: Run tests and Rubocop
         run: |


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.