### PR TITLE
Add back activesupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 LightService is a powerful and flexible service skeleton framework with an emphasis on simplicity
 
-🔥 **It now comes with no external gem dependency.** 🔥
-
 ## Table of Contents
 - [Table of Contents](#table-of-contents)
 - [Why LightService?](#why-lightservice)

--- a/lib/light-service.rb
+++ b/lib/light-service.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'active_support/core_ext/string'
 
 require 'light-service/version'
 

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -116,7 +116,7 @@ module LightService
     end
 
     def define_accessor_methods_for_keys(keys)
-      return if keys.blank?
+      return if keys.empty?
 
       Array(keys).each do |key|
         next if respond_to?(key.to_sym)

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |gem|
   gem.version       = LightService::VERSION
   gem.required_ruby_version = '>= 2.6.0'
 
+  gem.add_dependency("activesupport", ">= 5.0", "< 9.0")
+
   gem.add_development_dependency("generator_spec", "~> 0.9.4")
   gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.
   gem.add_development_dependency("rspec", "~> 3.0")


### PR DESCRIPTION
We are not ready to remove it. There are instances of `blank?` and `singularize` that are used in the code.

Removing `activesupport` still not fails any of the tests, as we have `generator_spec` that uses and installs `activesupport`.

Fixes #257  and #258.