### PR TITLE
change deprecation_warning method call

### DIFF
--- a/lib/light-service/organizer/verify_call_method_exists.rb
+++ b/lib/light-service/organizer/verify_call_method_exists.rb
@@ -15,7 +15,7 @@ module LightService
                       "its entry method (the one that calls with & reduce) " \
                       "should be named `call`. " \
                       "Please use #{klass}.call going forward."
-        LightService.deprecation_warning(warning_msg)
+        LightService::Deprecation.warn(warning_msg)
       end
 
       def self.caller_method(first_caller)

--- a/spec/acceptance/not_having_call_method_warning_spec.rb
+++ b/spec/acceptance/not_having_call_method_warning_spec.rb
@@ -4,8 +4,8 @@ require 'test_doubles'
 describe "Organizer should invoke with/reduce from a call method" do
   context "when the organizer does not have a `call` method" do
     it "gives warning" do
-      expect(LightService)
-        .to receive(:deprecation_warning)
+      expect(LightService::Deprecation)
+        .to receive(:warn)
         .with(/^The <OrganizerWithoutCallMethod> class is an organizer/)
 
       class OrganizerWithoutCallMethod


### PR DESCRIPTION
To address #264 

Disclaimer: I've never touched this repo so I might be missing something. I needed to update some other gems in one of my employers apps and found they were still on a 2017 version of this gem so I bumped it and that led me here. 

I was getting this when trying to run rspec on our app
```
       NoMethodError:
         undefined method `deprecation_warning' for LightService:Module

                 LightService.deprecation_warning(warning_msg)
                             ^^^^^^^^^^^^^^^^^^^^
         Did you mean?  deprecate_constant
```
and this is where I wound up tracing it to.

Thanks!

