### PR TITLE
Add ostruct as development dependency

### DIFF
--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rubocop", "~> 1.26.0")
   gem.add_development_dependency("rubocop-performance", "~> 1.2.0")
   gem.add_development_dependency("pry", "~> 0.14")
+  gem.add_development_dependency("ostruct", "~> 0.6")
 end


### PR DESCRIPTION
It will not be in future versions of Ruby.

Fixes #266.