### PR TITLE
Fix benchmark warning

### DIFF
--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("rubocop-performance", "~> 1.2.0")
   gem.add_development_dependency("pry", "~> 0.14")
   gem.add_development_dependency("ostruct", "~> 0.6")
+  gem.add_development_dependency("benchmark", "~> 0.3")
 end


### PR DESCRIPTION
/lib/active_support/core_ext/benchmark.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.

You can add benchmark to your Gemfile or gemspec to silence this warning.

Fixes #267 