### PR TITLE
Bump gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Lint/EmptyClass:
     - 'spec/**/*.rb'
 
 # Defaults after the Rubocop upgrade
-Gemspec/DateAssignment: # new in 1.10
+Gemspec/DeprecatedAttributeAssignment: # new in 1.10
   Enabled: true
 Layout/LineEndStringConcatenationIndentation: # new in 1.18
   Enabled: true

--- a/lib/light-service/organizer.rb
+++ b/lib/light-service/organizer.rb
@@ -55,8 +55,8 @@ module LightService
         Iterate.run(self, collection_key, steps)
       end
 
-      def execute(code_block)
-        Execute.run(code_block)
+      def execute(code_block = nil, &block)
+        Execute.run(code_block || block)
       end
 
       def with_callback(action, steps)

--- a/light-service.gemspec
+++ b/light-service.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("activesupport", ">= 5.0", "< 9.0")
 
-  gem.add_development_dependency("generator_spec", "~> 0.9.4")
-  gem.add_development_dependency("test-unit", "~> 3.0") # Needed for generator specs.
-  gem.add_development_dependency("rspec", "~> 3.0")
-  gem.add_development_dependency("simplecov", "~> 0.17")
+  gem.add_development_dependency("generator_spec", "~> 0.10")
+  gem.add_development_dependency("test-unit", "~> 3.6") # Needed for generator specs.
+  gem.add_development_dependency("rspec", "~> 3.13")
+  gem.add_development_dependency("simplecov", "~> 0.22")
   gem.add_development_dependency("simplecov-cobertura", "~> 2.1")
-  gem.add_development_dependency("rubocop", "~> 1.26.0")
-  gem.add_development_dependency("rubocop-performance", "~> 1.2.0")
-  gem.add_development_dependency("pry", "~> 0.14")
+  gem.add_development_dependency("rubocop", "~> 1.75")
+  gem.add_development_dependency("rubocop-performance", "~> 1.2")
+  gem.add_development_dependency("pry", "~> 0.15")
   gem.add_development_dependency("ostruct", "~> 0.6")
 end

--- a/spec/acceptance/organizer/reduce_if_spec.rb
+++ b/spec/acceptance/organizer/reduce_if_spec.rb
@@ -63,21 +63,19 @@ RSpec.describe LightService::Organizer do
         reduce(actions)
       end
 
-      # rubocop:disable Metrics/AbcSize
       def self.actions
         [
           reduce_if(
             ->(c) { !c.nil? },
             [
               execute(->(c) { c[:first_reduce_if] = true }),
-              execute(->(c) { c.skip_remaining! }),
+              execute(&:skip_remaining!),
               execute(->(c) { c[:second_reduce_if] = true })
             ]
           ),
           execute(->(c) { c[:last_outside] = true })
         ]
       end
-      # rubocop:enable Metrics/AbcSize
     end
 
     result = org.call


### PR DESCRIPTION
Only dev-dependencies.

After:

```
% bundle outdated
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...

Gem                  Current  Latest  Requested  Groups
rubocop              1.75.4   1.75.5  ~> 1.75    development
rubocop-performance  1.2.0    1.25.0  ~> 1.2     development
```

Fixes #270 