### PR TITLE
Update README.md to reflect before and after actions do not execute on every call to an organizer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,8 @@ Any object passed into `around_each` must respond to #call with two arguments: t
 
 ## Before and After Action Hooks
 
-In case you need to inject code right before and after the actions are executed, you can use the `before_actions` and `after_actions` hooks. It accepts one or multiple lambdas that the Action implementation will invoke. This addition to LightService is a great way to decouple instrumentation from business logic.  One important note is that these only execute on the first call the the organizer.  Subsequent calls will not call the before and after actions.
+In case you need to inject code right before and after the actions are executed, you can use the `before_actions` and `after_actions` hooks. It accepts one or multiple lambdas that the Action implementation will invoke. This addition to LightService is a great way to decouple instrumentation from business logic.
+One important note: these actions only run on the first call to the organizer. Subsequent calls will skip both the before and after actions.
 
 Consider this code:
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Any object passed into `around_each` must respond to #call with two arguments: t
 
 ## Before and After Action Hooks
 
-In case you need to inject code right before and after the actions are executed, you can use the `before_actions` and `after_actions` hooks. It accepts one or multiple lambdas that the Action implementation will invoke. This addition to LightService is a great way to decouple instrumentation from business logic.
+In case you need to inject code right before and after the actions are executed, you can use the `before_actions` and `after_actions` hooks. It accepts one or multiple lambdas that the Action implementation will invoke. This addition to LightService is a great way to decouple instrumentation from business logic.  One important note is that these only execute on the first call the the organizer.  Subsequent calls will not call the before and after actions.
 
 Consider this code:
 


### PR DESCRIPTION
Even though based on a previous bug report it seems as if this is not the intended behavior, it hasn't been addressed and the docs should reflect the current state not to confuse others.  I spent a little while debugging an issue around this and it'd be good to spare others that same frustration until a fix can be implemented.