### PR TITLE
Add Skip All functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ LightService is a powerful and flexible service skeleton framework with an empha
 - [Stopping the Series of Actions](#stopping-the-series-of-actions)
   - [Failing the Context](#failing-the-context)
   - [Skipping the rest of the actions](#skipping-the-rest-of-the-actions)
+  - [Skipping ALL the rest of the actions](#skipping-all-the-rest-of-the-actions)
 - [Benchmarking Actions with Around Advice](#benchmarking-actions-with-around-advice)
 - [Before and After Action Hooks](#before-and-after-action-hooks)
 - [Expects and Promises](#expects-and-promises)
@@ -396,6 +397,24 @@ end
 
 In the example above the organizer called 4 actions. The first 2 actions got executed successfully. The 3rd decided to skip the rest, the 4th action was not invoked. The context was successful.
 
+### Skipping ALL the rest of the actions
+While `context.skip_remaining!` skips actions in the current scope (e.g. inside a `reduce_if` or `iterate` block), sometimes you want to halt the entire execution of the organizer and any parent organizers. You can do this by calling `context.skip_all_remaining!`.
+
+Consider this example:
+
+```ruby
+def self.actions
+  [
+    reduce_if(->(ctx) { ctx.should_execute_conditional_actions }, [
+      ConditionallyRunAction1, # calls ctx.skip_all_remaining!
+      ConditionallyRunAction2, # skipped
+    ]),
+    AlwaysRunAction, # also skipped with skip_all_remaining!
+  ]
+end
+```
+
+In this case, `AlwaysRunAction` will be skipped if `skip_all_remaining!` was called inside the `reduce_if` block. If `skip_remaining!` had been used instead, `AlwaysRunAction` would still execute because the "skip" state is normally reset when exiting a scoped block.
 
 ## Benchmarking Actions with Around Advice
 Benchmarking your action is needed when you profile the series of actions. You could add benchmarking logic to each and every action, however, that would blur the business logic you have in your actions.

--- a/lib/light-service/context.rb
+++ b/lib/light-service/context.rb
@@ -18,6 +18,7 @@ module LightService
       @message = message
       @error_code = error_code
       @skip_remaining = false
+      @skip_all_remaining = false
 
       context.to_hash.each { |k, v| self[k] = v }
     end
@@ -49,6 +50,10 @@ module LightService
 
     def skip_remaining?
       @skip_remaining
+    end
+
+    def skip_all_remaining?
+      @skip_all_remaining
     end
 
     def reset_skip_remaining!
@@ -111,8 +116,13 @@ module LightService
       @skip_remaining = true
     end
 
+    def skip_all_remaining!(message = nil)
+      @message = message
+      @skip_all_remaining = true
+    end
+
     def stop_processing?
-      failure? || skip_remaining?
+      failure? || skip_remaining? || skip_all_remaining?
     end
 
     def define_accessor_methods_for_keys(keys)
@@ -153,7 +163,8 @@ module LightService
 
     def inspect
       "#{self.class}(#{self}, success: #{success?}, message: #{check_nil(message)}, error_code: " \
-        "#{check_nil(error_code)}, skip_remaining: #{@skip_remaining}, aliases: #{@aliases})"
+        "#{check_nil(error_code)}, skip_remaining: #{@skip_remaining}, " \
+        "skip_all_remaining: #{@skip_all_remaining}, aliases: #{@aliases})"
     end
 
     private

--- a/lib/light-service/organizer/iterate.rb
+++ b/lib/light-service/organizer/iterate.rb
@@ -10,6 +10,8 @@ module LightService
           collection = ctx[collection_key]
           item_key = collection_key.to_s.singularize.to_sym
           collection.each do |item|
+            break if ctx.stop_processing?
+
             ctx[item_key] = item
             ctx = scoped_reduce(organizer, ctx, steps)
           end

--- a/lib/light-service/organizer/reduce_until.rb
+++ b/lib/light-service/organizer/reduce_until.rb
@@ -9,7 +9,7 @@ module LightService
 
           loop do
             ctx = scoped_reduce(organizer, ctx, steps)
-            break if condition_block.call(ctx) || ctx.failure?
+            break if condition_block.call(ctx) || ctx.stop_processing?
           end
 
           ctx

--- a/lib/light-service/organizer/with_reducer_log_decorator.rb
+++ b/lib/light-service/organizer/with_reducer_log_decorator.rb
@@ -91,7 +91,8 @@ module LightService
       end
 
       def skip_remaining?(context)
-        context.respond_to?(:skip_remaining?) && context.skip_remaining?
+        (context.respond_to?(:skip_remaining?) && context.skip_remaining?) ||
+          (context.respond_to?(:skip_all_remaining?) && context.skip_all_remaining?)
       end
 
       def write_skip_remaining_log(context, action)

--- a/spec/acceptance/skip_all_remaining_spec.rb
+++ b/spec/acceptance/skip_all_remaining_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+RSpec.describe "skip_all_remaining!" do
+  context "with regular organizer" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions
+          [
+            execute(->(c) { c[:first] = true }),
+            execute(lambda(&:skip_all_remaining!)),
+            execute(->(c) { c[:second] = true })
+          ]
+        end
+      end
+    end
+
+    it "skips all remaining actions" do
+      result = organizer.call(LightService::Context.make)
+
+      expect(result[:first]).to be true
+      expect(result[:second]).to be_nil
+    end
+  end
+
+  context "with an organizer with a reducer" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions
+          [
+            reduce_if(
+              ->(_) { true },
+              [
+                execute(->(c) { c[:first_inside] = true }),
+                execute(lambda(&:skip_all_remaining!)),
+                execute(->(c) { c[:second_inside] = true })
+              ]
+            ),
+            execute(->(c) { c[:outside] = true })
+          ]
+        end
+      end
+    end
+
+    it "skips all remaining actions inside and outside the reducer" do
+      result = organizer.call(LightService::Context.make)
+
+      expect(result[:first_inside]).to be true
+      expect(result[:second_inside]).to be_nil
+      expect(result[:outside]).to be_nil
+    end
+  end
+
+  context "with an organizer with nested reducers" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+          [
+            reduce_if(
+              ->(_) { true },
+              [
+                iterate(:items, [
+                          execute(lambda { |c|
+                            c[:executed_items] ||= []
+                            c[:executed_items] << c[:item]
+                          }),
+                          execute(->(c) { c.skip_all_remaining! if c[:item] == 2 }),
+                          execute(lambda { |c|
+                            c[:skipped_in_iterate] ||= []
+                            c[:skipped_in_iterate] << c[:item]
+                          })
+                        ]),
+                execute(->(c) { c[:after_iterate_inside_if] = true })
+              ]
+            ),
+            execute(->(c) { c[:outside] = true })
+          ]
+        end
+      end
+    end
+
+    it "skips all remaining actions across all nested scopes" do
+      result = organizer.call(LightService::Context.make(:items => [1, 2, 3]))
+
+      expect(result[:executed_items]).to eq([1, 2])
+      expect(result[:skipped_in_iterate]).to eq([1])
+      expect(result[:after_iterate_inside_if]).to be_nil
+      expect(result[:outside]).to be_nil
+    end
+  end
+end

--- a/spec/acceptance/skip_remaining_spec.rb
+++ b/spec/acceptance/skip_remaining_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe "skip_remaining!" do
+  context "with regular organizer" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions
+          [
+            execute(->(c) { c[:first] = true }),
+            execute(lambda(&:skip_remaining!)),
+            execute(->(c) { c[:second] = true })
+          ]
+        end
+      end
+    end
+
+    it "skips the remaining actions in the organizer" do
+      result = organizer.call(LightService::Context.make)
+
+      expect(result[:first]).to be true
+      expect(result[:second]).to be_nil
+    end
+  end
+
+  context "with an organizer with a reducer" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions # rubocop:disable Metrics/AbcSize
+          [
+            iterate(:items, [
+                      execute(lambda { |c|
+                        c[:executed_items] ||= []
+                        c[:executed_items] << c[:item]
+                      }),
+                      execute(->(c) { c.skip_remaining! if c[:item] == 2 }),
+                      execute(lambda { |c|
+                        c[:skipped_actions] ||= []
+                        c[:skipped_actions] << c[:item]
+                      })
+                    ]),
+            execute(->(c) { c[:outside_iterate] = true })
+          ]
+        end
+      end
+    end
+
+    it "only skips remaining actions for the current item in the reducer" do
+      result = organizer.call(LightService::Context.make(:items => [1, 2, 3]))
+
+      expect(result[:executed_items]).to eq([1, 2, 3])
+      expect(result[:skipped_actions]).to eq([1, 3])
+      expect(result[:outside_iterate]).to be true
+    end
+  end
+end
+

--- a/spec/context/inspect_spec.rb
+++ b/spec/context/inspect_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe LightService::Context do
   describe '#inspect' do
     it 'inspects the hash with all the fields' do
       inspected_context =
-        "LightService::Context({}, success: true, message: '', error_code: nil, skip_remaining: false, aliases: {})"
+        "LightService::Context({}, success: true, message: '', error_code: nil, skip_remaining: false, " \
+        "skip_all_remaining: false, aliases: {})"
 
       expect(context.inspect).to eq(inspected_context)
     end
@@ -23,7 +24,7 @@ RSpec.describe LightService::Context do
 
       inspected_context =
         "LightService::Context({}, success: false, message: 'There was an error', error_code: nil, " \
-        "skip_remaining: false, aliases: {})"
+        "skip_remaining: false, skip_all_remaining: false, aliases: {})"
 
       expect(context.inspect).to eq(inspected_context)
     end
@@ -33,7 +34,7 @@ RSpec.describe LightService::Context do
 
       inspected_context =
         "LightService::Context({}, success: true, message: 'No need to process', error_code: nil, " \
-        "skip_remaining: true, aliases: {})"
+        "skip_remaining: true, skip_all_remaining: false, aliases: {})"
 
       expect(context.inspect).to eq(inspected_context)
     end


### PR DESCRIPTION
# Description

This PR adds skip all functionality described [here](https://github.com/adomokos/light-service/issues/275).

While `context.skip_remaining!` skips actions in the current scope (e.g. inside a `reduce_if` or `iterate` block), sometimes you want to halt the entire execution of the organizer and any parent organizers. You can do this by calling `context.skip_all_remaining!`.

Consider this example:

```ruby
def self.actions
  [
    reduce_if(->(ctx) { ctx.should_execute_conditional_actions }, [
      ConditionallyRunAction1, # calls ctx.skip_all_remaining!
      ConditionallyRunAction2, # skipped
    ]),
    AlwaysRunAction, # also skipped with skip_all_remaining!
  ]
end
```

In this case, `AlwaysRunAction` will be skipped if `skip_all_remaining!` was called inside the `reduce_if` block. If `skip_remaining!` had been used instead, `AlwaysRunAction` would still execute because the "skip" state is normally reset when exiting a scoped block.

# Testing

- [x] Added test scenarios for the new functionality.
- [x] Verified that previous tests still work.