### PR TITLE
Fix skip_all_remaining! message preservation

### DIFF
--- a/lib/light-service/organizer/scoped_reducable.rb
+++ b/lib/light-service/organizer/scoped_reducable.rb
@@ -2,9 +2,9 @@ module LightService
   module Organizer
     module ScopedReducable
       def scoped_reduce(organizer, ctx, steps)
-        ctx.reset_skip_remaining! unless ctx.failure?
+        ctx.reset_skip_remaining! unless ctx.failure? || ctx.skip_all_remaining?
         ctx = organizer.with(ctx).reduce([steps])
-        ctx.reset_skip_remaining! unless ctx.failure?
+        ctx.reset_skip_remaining! unless ctx.failure? || ctx.skip_all_remaining?
 
         ctx
       end

--- a/spec/acceptance/skip_all_remaining_spec.rb
+++ b/spec/acceptance/skip_all_remaining_spec.rb
@@ -62,6 +62,37 @@ RSpec.describe "skip_all_remaining!" do
     end
   end
 
+  context "with a message" do
+    let(:organizer) do
+      Class.new do
+        extend LightService::Organizer
+
+        def self.call(ctx)
+          with(ctx).reduce(actions)
+        end
+
+        def self.actions
+          [
+            reduce_if(
+              ->(_) { true },
+              [
+                execute(->(c) { c.skip_all_remaining!("Skipping with message") })
+              ]
+            ),
+            execute(->(c) { c[:outside] = true })
+          ]
+        end
+      end
+    end
+
+    it "preserves the message when exiting scoped reducers" do
+      result = organizer.call(LightService::Context.make)
+
+      expect(result.message).to eq("Skipping with message")
+      expect(result[:outside]).to be_nil
+    end
+  end
+
   context "with an organizer with nested reducers" do
     let(:organizer) do
       Class.new do


### PR DESCRIPTION
Prevents the context message from being cleared when skip_all_remaining! is called inside a scoped reducer (reduce_if, iterate, etc.).
Adds test coverage for message preservation.

/cc @sncalvo.
